### PR TITLE
ci: adopt Chat-ERP governance checks (issue #9 tranche A)

### DIFF
--- a/.github/workflows/ci-guardrails.yml
+++ b/.github/workflows/ci-guardrails.yml
@@ -1,0 +1,112 @@
+name: CI Guardrails
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  area-label-scope-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce changed-files scope from issue area label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumberMatch = `${pr.title || ""}\n${pr.body || ""}`.match(/#(\d+)/);
+
+            if (!issueNumberMatch) {
+              core.setFailed("Could not determine linked issue number from PR title/body. Include 'Closes #<number>' in PR.");
+              return;
+            }
+
+            const issue_number = Number(issueNumberMatch[1]);
+            const issue = await github.rest.issues.get({ owner, repo, issue_number });
+            const issueLabels = (issue.data.labels || []).map((l) => typeof l === "string" ? l : l.name);
+            const areaLabels = issueLabels.filter((l) => /^area:/.test(l));
+
+            if (areaLabels.length !== 1) {
+              core.setFailed(`Linked issue #${issue_number} must have exactly one area:* label. Found: ${areaLabels.join(", ") || "none"}`);
+              return;
+            }
+
+            const area = areaLabels[0];
+            const allowlistByArea = {
+              "area:infra": [".github/", "docs/", "frameworks/", "templates/", "case-studies/", "content/", "src/", "public/", ".gitignore", "README.md", "CONTRIBUTING.md"],
+              "area:frontend": ["src/", "content/", "public/", "docs/", "templates/"],
+              "area:backend": ["docs/", "frameworks/", "templates/"],
+              "area:db": ["docs/", "templates/"],
+              "area:sre": [".github/", "docs/", "frameworks/", "templates/"],
+              "area:security": [".github/", "docs/", "frameworks/", "templates/", "src/", "content/"],
+              "area:release": [".github/", "docs/", "templates/", "README.md"],
+              "area:design": ["docs/", "content/", "src/", "public/", "templates/"]
+            };
+
+            const allowPrefixes = allowlistByArea[area];
+            if (!allowPrefixes) {
+              core.setFailed(`Unsupported area label '${area}' for scope enforcement.`);
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+
+            const changed = files.map((f) => f.filename);
+            const disallowed = changed.filter((f) => !allowPrefixes.some((prefix) => f === prefix || f.startsWith(prefix)));
+
+            if (disallowed.length > 0) {
+              core.setFailed(
+                `PR changes violate scope for ${area}. Allowed prefixes: ${allowPrefixes.join(", ")}. Disallowed files: ${disallowed.join(", ")}`
+              );
+            }
+
+  proof-artifact-comment-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate linked issue proof comment exists
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumberMatch = `${pr.title || ""}\n${pr.body || ""}`.match(/#(\d+)/);
+
+            if (!issueNumberMatch) {
+              core.setFailed("Could not determine linked issue number from PR title/body. Include 'Closes #<number>' in PR.");
+              return;
+            }
+
+            const issue_number = Number(issueNumberMatch[1]);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+
+            const prUrl = pr.html_url;
+            const shaRegex = /\b[0-9a-f]{40}\b/i;
+            const validationRegex = /(Validation:|lint\s*✅|typecheck\s*✅|test\s*✅|build\s*✅)/i;
+
+            const proofComment = comments.find((c) => {
+              const body = c.body || "";
+              return body.includes(prUrl) && shaRegex.test(body) && validationRegex.test(body);
+            });
+
+            if (!proofComment) {
+              core.setFailed(
+                `No linked issue comment on #${issue_number} contains required proof bundle for this PR (${prUrl}). Expected PR URL + 40-char commit SHA + validation summary.`
+              );
+            }

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,0 +1,55 @@
+name: PR Issue Link Enforcement
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled, ready_for_review]
+
+jobs:
+  require-issue-link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR has linked issue and evidence artifacts
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const title = pr.title || "";
+            const labels = (pr.labels || []).map(l => l.name);
+
+            const hasBootstrapException = labels.includes("exception:bootstrap");
+
+            const issuePatterns = [
+              /(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+/i,
+              /(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+https:\/\/github\.com\/.+\/issues\/\d+/i,
+              /related\s+to\s+#\d+/i,
+              /issue\s+#\d+/i
+            ];
+
+            const text = `${title}\n${body}`;
+            const hasIssueLink = issuePatterns.some((p) => p.test(text));
+
+            const evidenceRequirements = [
+              { key: "summary", regex: /^##\s*Summary\b/im, hint: "Add a '## Summary' section." },
+              { key: "why", regex: /^##\s*Why\b/im, hint: "Add a '## Why' section." },
+              { key: "tests", regex: /^##\s*Tests\b/im, hint: "Add a '## Tests' section." },
+              { key: "risk", regex: /^##\s*Risk\s*&\s*Rollback\b/im, hint: "Add a '## Risk & Rollback' section." },
+              { key: "security", regex: /^##\s*Security\s*&\s*Data\b/im, hint: "Add a '## Security & Data' section." }
+            ];
+
+            const missingEvidence = evidenceRequirements
+              .filter((req) => !req.regex.test(body))
+              .map((req) => req.hint);
+
+            if (!hasIssueLink && !hasBootstrapException) {
+              core.setFailed(
+                "PR must link an issue (e.g. 'Closes #123'). Only first-time repo bootstrap PRs may use label 'exception:bootstrap'."
+              );
+              return;
+            }
+
+            if (missingEvidence.length > 0 && !hasBootstrapException) {
+              core.setFailed(
+                `PR description is missing required evidence sections: ${missingEvidence.join(" ")}`
+              );
+            }

--- a/docs/ci/governance-validation-plan.md
+++ b/docs/ci/governance-validation-plan.md
@@ -1,0 +1,43 @@
+# Governance CI Validation Plan (Issue #9)
+
+This document defines the fail/pass validation scenarios for governance checks.
+
+## Checks under validation
+- `.github/workflows/pr-issue-link.yml`
+- `.github/workflows/ci-guardrails.yml`
+
+## Scenario matrix
+
+### 1) Missing issue link in PR body
+- Expected: `require-issue-link` fails
+- Fix: add `Closes #<issue>`
+- Expected after fix: pass
+
+### 2) Missing required PR evidence sections
+- Expected: `require-issue-link` fails with missing sections
+- Fix: add sections:
+  - Summary
+  - Why
+  - Tests
+  - Risk & Rollback
+  - Security & Data
+- Expected after fix: pass
+
+### 3) Out-of-scope files for issue `area:*`
+- Expected: `area-label-scope-check` fails and lists disallowed files
+- Fix: remove/split out-of-scope changes or update issue area label appropriately
+- Expected after fix: pass
+
+### 4) Missing proof-bundle issue comment
+- Expected: `proof-artifact-comment-check` fails
+- Fix: post issue comment containing:
+  - PR URL
+  - full 40-char commit SHA
+  - Validation summary (`Validation: ...`)
+- Expected after fix: pass
+
+## Evidence format
+For each scenario, capture:
+- failing run URL
+- passing run URL
+- short note with root cause and fix


### PR DESCRIPTION
## Summary
- port generic governance CI rules from Chat-ERP into this repo
- add PR issue-link enforcement workflow (`pr-issue-link.yml`)
- add area-scope + proof-artifact guardrail workflow (`ci-guardrails.yml`)
- add governance validation scenario plan for fail/pass test runs

## Why
Issue #9 requires governance check validation. First we need the same baseline guardrails active in this portfolio repo.

Refs #9

## Tests
- Validation: workflow syntax reviewed and pushed to branch for PR-trigger execution
- Validation: scenario matrix documented in `docs/ci/governance-validation-plan.md`

## Risk & Rollback
- Risk: strict scope allowlists can initially fail legitimate PRs until labels/files align.
- Rollback: revert workflow files or relax allowlists while calibrating.

## Security & Data
- No runtime app data impact.
- Improves governance and auditability for repository change control.
