### PR TITLE
ci: permit web/ scope for frontend implementation lanes (refs #9)

### DIFF
--- a/.github/workflows/ci-guardrails.yml
+++ b/.github/workflows/ci-guardrails.yml
@@ -39,8 +39,8 @@ jobs:
 
             const area = areaLabels[0];
             const allowlistByArea = {
-              "area:infra": [".github/", "docs/", "frameworks/", "templates/", "case-studies/", "content/", "src/", "public/", ".gitignore", "README.md", "CONTRIBUTING.md"],
-              "area:frontend": ["src/", "content/", "public/", "docs/", "templates/"],
+              "area:infra": [".github/", "docs/", "frameworks/", "templates/", "case-studies/", "content/", "src/", "web/", "public/", ".gitignore", "README.md", "CONTRIBUTING.md"],
+              "area:frontend": ["src/", "web/", "content/", "public/", "docs/", "templates/"],
               "area:backend": ["docs/", "frameworks/", "templates/"],
               "area:db": ["docs/", "templates/"],
               "area:sre": [".github/", "docs/", "frameworks/", "templates/"],


### PR DESCRIPTION
## Summary
- update area scope allowlists to include `web/` paths
- allow frontend and infra tickets to modify website implementation under `web/`

## Why
Portfolio implementation is located under `web/`; current scope guardrails would incorrectly fail valid frontend/infra changes.

Issue #9

## Tests
- Validation: updated allowlist map in `.github/workflows/ci-guardrails.yml`

## Risk & Rollback
- Risk: broadened scope could allow unintended web changes under infra tickets.
- Rollback: revert allowlist update if stricter partitioning is required.

## Security & Data
- Governance-only workflow adjustment; no runtime/data impact.
