### PR TITLE
feat(web): #5A layout/nav shell with anchored section scaffolding

### DIFF
--- a/web/src/components/SiteNav.astro
+++ b/web/src/components/SiteNav.astro
@@ -1,0 +1,55 @@
+---
+const items = [
+  { href: '#case-studies', label: 'Work' },
+  { href: '#ai-governance', label: 'AI Risk' },
+  { href: '#experience', label: 'Experience' },
+  { href: '#web-foundry', label: 'Web Foundry' },
+  { href: '#contact', label: 'Contact' },
+];
+---
+
+<a class="skip-link" href="#main-content">Skip to content</a>
+<header class="site-header" role="banner">
+  <div class="container nav-wrap">
+    <a class="brand" href="#hero">Neil Sinha</a>
+    <nav aria-label="Primary">
+      <ul>
+        {items.map((item) => (
+          <li><a href={item.href}>{item.label}</a></li>
+        ))}
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<style>
+  .skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    background: #0f172a;
+    color: #fff;
+    padding: 0.5rem 0.75rem;
+    z-index: 100;
+  }
+  .skip-link:focus { left: 0.75rem; top: 0.75rem; }
+  .site-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    backdrop-filter: blur(8px);
+    background: color-mix(in oklab, #ffffff 88%, #f1f5f9 12%);
+    border-bottom: 1px solid #e2e8f0;
+  }
+  .container { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+  .nav-wrap { min-height: 64px; display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+  .brand { font-weight: 700; color: #0f172a; text-decoration: none; }
+  ul { display: flex; gap: 1rem; list-style: none; padding: 0; margin: 0; }
+  a { color: #334155; text-decoration: none; }
+  a:hover, a:focus-visible { color: #0f172a; text-decoration: underline; }
+
+  @media (max-width: 760px) {
+    .nav-wrap { flex-direction: column; align-items: flex-start; padding: 0.75rem 1.25rem; }
+    ul { flex-wrap: wrap; gap: 0.75rem; }
+  }
+</style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Layout from '../layouts/Layout.astro';
+import SiteNav from '../components/SiteNav.astro';
 
 const [metaEntry] = await getCollection('meta');
 const caseStudies = (await getCollection('case-studies')).sort((a, b) => a.data.order - b.data.order);
@@ -11,11 +12,27 @@ const meta = metaEntry?.data;
 ---
 
 <Layout>
-  <main class="page">
+  <SiteNav />
+  <main id="main-content" class="page">
     <section id="hero" class="section hero">
       <p class="eyebrow">Neil Sinha · Platform + AI Engineering</p>
       <h1>{meta?.heroTitle}</h1>
       <p class="subtitle">{meta?.heroSubtitle}</p>
+    </section>
+
+    <section id="problem-landscape" class="section">
+      <h2>Problem Landscape</h2>
+      <p class="subtitle">Cloud cost drift, CI instability, and AI governance gaps are recurring delivery risks. This portfolio focuses on measured interventions that reduce those risks.</p>
+    </section>
+
+    <section id="operating-philosophy" class="section">
+      <h2>Operating Philosophy</h2>
+      <div class="grid">
+        <article class="card"><h3>Cost Discipline</h3><p>Engineer systems so spend stays forecastable and aligned to business value.</p></article>
+        <article class="card"><h3>Reliability First</h3><p>Prefer repeatable release patterns and fast recovery over brittle speed.</p></article>
+        <article class="card"><h3>Observability</h3><p>Expose health, latency, and integrity signals early so issues surface before incidents.</p></article>
+        <article class="card"><h3>Safe AI Adoption</h3><p>Use governance checks and auditable workflows so acceleration does not bypass control.</p></article>
+      </div>
     </section>
 
     <section id="case-studies" class="section">
@@ -69,6 +86,16 @@ const meta = metaEntry?.data;
       </div>
     </section>
 
+    <section id="web-foundry" class="section">
+      <h2>Web Foundry</h2>
+      <p class="subtitle">Operator-led consulting focused on platform modernization, delivery reliability, and AI governance implementation.</p>
+    </section>
+
+    <section id="trust" class="section">
+      <h2>Trust Layer</h2>
+      <p class="subtitle">Leadership history includes ANZ, Humanforce, and contract delivery in regulated environments.</p>
+    </section>
+
     <section id="contact" class="section cta">
       <h2>{meta?.ctaPrimary}</h2>
       <p>{meta?.ctaRecruiter}</p>
@@ -79,13 +106,13 @@ const meta = metaEntry?.data;
 </Layout>
 
 <style>
-  .page { max-width: 1100px; margin: 0 auto; padding: 3rem 1.25rem 5rem; font-family: Inter, system-ui, -apple-system, sans-serif; color: #0f172a; }
-  .section { margin: 0 0 4rem; }
+  .page { max-width: 1100px; margin: 0 auto; padding: 2rem 1.25rem 5rem; font-family: Inter, system-ui, -apple-system, sans-serif; color: #0f172a; }
+  .section { margin: 0 0 4rem; scroll-margin-top: 90px; }
   .hero { padding-top: 1rem; }
   .eyebrow { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.08em; color: #475569; }
   h1 { font-size: clamp(2rem, 5vw, 3.5rem); line-height: 1.1; margin: 0.5rem 0 1rem; }
   h2 { font-size: clamp(1.5rem, 3vw, 2rem); margin-bottom: 1rem; }
-  .subtitle { font-size: 1.1rem; color: #334155; max-width: 800px; }
+  .subtitle { font-size: 1.1rem; color: #334155; max-width: 850px; }
   .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
   .card { border: 1px solid #e2e8f0; border-radius: 12px; padding: 1rem; background: #fff; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.03); }
   .card h3 { margin-top: 0; font-size: 1.05rem; }


### PR DESCRIPTION
## Summary
- add reusable `SiteNav` component with sticky header and skip-link
- wire primary anchors for Work / AI Risk / Experience / Web Foundry / Contact
- scaffold missing narrative sections from IA spec (`problem-landscape`, `operating-philosophy`, `trust`)
- keep homepage content-backed while preparing UI polish tranches

## Why
Related to #5. This is tranche A (layout + navigation shell) so we can layer visual system and interaction polish in smaller, lower-risk PRs.

Related to #5

## Tests
- `cd web && npm run astro -- check`
- `cd web && npm run build`
- Result: pass (no errors)

## Risk & Rollback
- Risk: nav/header style may change during #5B polish.
- Rollback: revert `SiteNav` and index layout changes.

## Security & Data
- Frontend-only static rendering changes; no secrets/auth/data-path changes.
