### PR TITLE
ci(web): add Lighthouse + accessibility gates for portfolio PRs (closes #10)

### DIFF
--- a/.github/lighthouse/lighthouserc.json
+++ b/.github/lighthouse/lighthouserc.json
@@ -1,0 +1,23 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 1,
+      "staticDistDir": "web/dist",
+      "url": ["http://localhost/"],
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:performance": ["warn", { "minScore": 0.7 }],
+        "categories:best-practices": ["warn", { "minScore": 0.8 }],
+        "categories:seo": ["warn", { "minScore": 0.8 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/.github/workflows/web-quality.yml
+++ b/.github/workflows/web-quality.yml
@@ -1,0 +1,49 @@
+name: Web Quality Gates
+
+on:
+  pull_request:
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-quality.yml'
+      - '.github/lighthouse/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse-and-a11y:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Build web
+        run: npm run build
+        working-directory: web
+
+      - name: Run Lighthouse CI (includes accessibility assertions)
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: .github/lighthouse/lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+
+      - name: Upload web dist artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-dist
+          path: web/dist
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a dedicated web quality workflow for PRs touching `web/**`
- run web build in CI before quality checks
- enforce Lighthouse accessibility threshold via LHCI assertions
- upload Lighthouse and built-site artifacts for auditability

## Why
Issue #10 requires automated Lighthouse and accessibility quality gates on portfolio changes so regressions are caught pre-merge.

Closes #10

## Tests
- Local: `cd web && npm run build` (pass)
- CI: `Web Quality Gates` workflow executes Lighthouse CI assertions and fails on accessibility threshold breach

## Risk & Rollback
- Risk: strict thresholds may initially fail valid PRs while baseline UI quality matures.
- Rollback: lower/assertion thresholds or revert `web-quality.yml` and `.github/lighthouse/lighthouserc.json`.

## Security & Data
- CI-only change, no production runtime data-path changes.
- Artifacts are build outputs and Lighthouse reports only.
