### PR TITLE
docs(release): add preview/prod validation evidence bundle (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This repository distills battle-tested patterns from real-world execution into p
 
 - Promotion checklist: `docs/release/promotion-checklist.md`
 - Rollback playbook: `docs/release/rollback-playbook.md`
+- Validation evidence: `docs/release/validation-evidence.md`
 
 ## License
 

--- a/docs/release/validation-evidence.md
+++ b/docs/release/validation-evidence.md
@@ -1,0 +1,28 @@
+# Release Validation Evidence
+
+Issue: #11
+
+## 1) Preview evidence on PR
+- PR run (preview artifact + PR comment):
+  - https://github.com/neil795/neil-sinha-IT-portfolio/actions/runs/23403960108
+- Outcome:
+  - `build-artifact` passed
+  - `preview-pr-comment` posted preview evidence link and artifact name
+
+## 2) Production promotion dry run
+- Manual dispatch run (`target=production`):
+  - https://github.com/neil795/neil-sinha-IT-portfolio/actions/runs/23403980634
+- Outcome:
+  - `build-artifact` passed
+  - `promote-production` executed with immutable artifact metadata (`web-dist-<sha>`)
+
+## 3) Rollback path verification
+- Rollback instructions source:
+  - `docs/release/rollback-playbook.md`
+- Verified path includes:
+  - last-known-good SHA recovery
+  - artifact-based re-promotion
+  - post-rollback verification checklist
+
+## Notes
+- Production environment approvals can be tightened further via repository environment protection rules.


### PR DESCRIPTION
## Summary
- add release validation evidence document with concrete Actions run links
- capture preview PR artifact/comment evidence
- capture production promotion dry-run evidence via workflow_dispatch
- link release validation evidence from README

## Why
Issue #11 requires end-to-end dry-run evidence for preview and production promotion controls, plus rollback verification traceability.

Closes #11

## Tests
- Validation evidence links:
  - Preview run: https://github.com/neil795/neil-sinha-IT-portfolio/actions/runs/23403960108
  - Production dry run: https://github.com/neil795/neil-sinha-IT-portfolio/actions/runs/23403980634
- Rollback simulation path validated against `docs/release/rollback-playbook.md`

## Risk & Rollback
- Risk: run URLs remain valid subject to Actions retention policy.
- Rollback: docs-only change, safe to revert.

## Security & Data
- Documentation-only update; no application runtime/data impact.
