### PR TITLE
sre: add uptime baseline, alert policy, and incident runbook (closes #8)

### DIFF
--- a/.github/workflows/sre-monitoring.yml
+++ b/.github/workflows/sre-monitoring.yml
@@ -1,0 +1,34 @@
+name: SRE Monitoring Baseline
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  uptime-and-budget-check:
+    runs-on: ubuntu-latest
+    env:
+      SITE_URL: ${{ vars.PORTFOLIO_SITE_URL || 'https://neil-sinha-it-portfolio.pages.dev' }}
+      SLO_TARGET: '99.5'
+      ERROR_BUDGET_MINUTES_PER_30D: '216'
+    steps:
+      - name: Uptime probe
+        run: |
+          echo "Checking $SITE_URL"
+          status=$(curl -s -o /dev/null -w "%{http_code}" "$SITE_URL")
+          if [ "$status" -lt 200 ] || [ "$status" -ge 400 ]; then
+            echo "Uptime check failed with status $status"
+            exit 1
+          fi
+          echo "Uptime check passed with status $status"
+
+      - name: Emit baseline policy summary
+        run: |
+          echo "SLO target: ${SLO_TARGET}% availability"
+          echo "Error budget (30d): ${ERROR_BUDGET_MINUTES_PER_30D} minutes"
+          echo "Escalation map: docs/sre/escalation-map.md"
+          echo "Incident runbook: docs/sre/incident-runbook.md"

--- a/docs/sre/escalation-map.md
+++ b/docs/sre/escalation-map.md
@@ -1,0 +1,16 @@
+# Escalation Map
+
+## Ownership
+- Service owner: Neil Sinha
+- Operations owner: Web Foundry
+
+## Escalation path
+1. Alert detected by scheduled synthetic check.
+2. Open incident issue with severity label.
+3. Trigger rollback if customer-impacting.
+4. Post-incident review within 24h for SEV-1/SEV-2.
+
+## Alert policy
+- Probe interval: 30 minutes
+- Alert threshold: single failed check opens investigation; two consecutive failures = incident.
+- Error budget target: 99.5% monthly availability.

--- a/docs/sre/incident-runbook.md
+++ b/docs/sre/incident-runbook.md
@@ -1,0 +1,22 @@
+# Incident Runbook (Portfolio Site)
+
+## Severity model
+- **SEV-1**: Site unavailable or critical CTA broken
+- **SEV-2**: Major degradation (latency, broken key sections)
+- **SEV-3**: Minor defects with workaround
+
+## First-response checklist
+1. Confirm synthetic uptime failure (`SRE Monitoring Baseline` workflow).
+2. Verify current deployment SHA and latest successful release run.
+3. Assess blast radius (homepage, nav, CTA, accessibility).
+4. If SEV-1/SEV-2: execute rollback from `docs/release/rollback-playbook.md`.
+
+## Escalation
+- Primary owner: Neil Sinha
+- Secondary fallback: Web Foundry on-call rotation
+- Communication channel: GitHub issue + release thread
+
+## Recovery verification
+- HTTP 200 on homepage
+- Anchored navigation functional
+- Lighthouse accessibility >= 0.90

--- a/docs/sre/reliability-baseline.md
+++ b/docs/sre/reliability-baseline.md
@@ -1,0 +1,17 @@
+# Reliability Baseline
+
+## SLO
+- Availability target: **99.5%** monthly
+- Error budget: **216 minutes / 30 days**
+
+## Synthetic checks
+- Scheduled uptime probe every 30 minutes (`.github/workflows/sre-monitoring.yml`)
+- Manual on-demand probe via workflow_dispatch
+
+## Monitoring baseline
+- Uptime HTTP status check (>=200 and <400)
+- Lighthouse accessibility gate in PR CI (`Web Quality Gates` workflow)
+
+## Response policy
+- One failed probe: investigate
+- Two consecutive failures: declare incident and execute runbook


### PR DESCRIPTION
## Summary
- add scheduled uptime monitoring workflow (`sre-monitoring.yml`)
- define reliability baseline (SLO/error budget)
- add escalation map and incident response mini-runbook
- document mitigation path via release rollback playbook linkage

## Why
Issue #8 requires observability/reliability baseline, alert policy, and escalation model for site operations.

Closes #8

## Tests
- Validation: monitoring workflow supports schedule + manual dispatch
- Validation: reliability policy and incident docs merged under `docs/sre/`

## Risk & Rollback
- Risk: default SITE_URL may need repo variable override for final production domain.
- Rollback: revert `.github/workflows/sre-monitoring.yml` and `docs/sre/*`.

## Security & Data
- Operational monitoring/docs only; no user data handling changes.
