### PR TITLE
docs(ci): governance quickstart + contributor references (closes #6)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,8 @@ This repo follows playbook-first delivery and proof-based completion.
 
 ## Quality rule
 Do not mark done without evidence.
+
+## Governance quick references
+- `docs/ci/governance-quickstart.md`
+- `docs/ci/governance-validation-plan.md`
+- `docs/ci/governance-validation-results.md`

--- a/docs/ci/governance-quickstart.md
+++ b/docs/ci/governance-quickstart.md
@@ -1,0 +1,29 @@
+# Governance Quickstart
+
+This repo enforces Chat-ERP style governance checks on every pull request.
+
+## Checks enforced
+1. **Issue link required** (`pr-issue-link.yml`)
+   - PR must include an issue reference (e.g. `Closes #123`)
+   - PR body must include sections: Summary, Why, Tests, Risk & Rollback, Security & Data
+
+2. **Area scope guardrails** (`ci-guardrails.yml`)
+   - Linked issue must have exactly one `area:*` label
+   - Changed files must remain inside allowlisted prefixes for that area
+
+3. **Proof-bundle comment check** (`ci-guardrails.yml`)
+   - Linked issue must contain a comment with:
+     - PR URL
+     - 40-char commit SHA
+     - validation summary
+
+## Contributor workflow example
+1. Create issue with exactly one area label.
+2. Open branch: `feat/<issue>-<slug>`.
+3. Open PR and include `Closes #<issue>`.
+4. Add issue proof comment with PR URL + full SHA + validation.
+5. Merge only after all checks pass.
+
+## Evidence references
+- Validation plan: `docs/ci/governance-validation-plan.md`
+- Executed fail/pass runs: `docs/ci/governance-validation-results.md`


### PR DESCRIPTION
## Summary
- add governance quickstart explaining enforced PR checks and required proof format
- add contributor references to governance validation plan/results docs
- provide concrete issue->branch->PR->proof workflow example

## Why
Issue #6 requires governance discipline adoption to be both enforced in CI and documented for contributors with practical examples.

Closes #6

## Tests
- Validation: governance doc references existing enforced workflows (`pr-issue-link.yml`, `ci-guardrails.yml`)
- Validation: contributor docs now include direct governance references and evidence docs

## Risk & Rollback
- Risk: documentation may drift if workflows change names.
- Rollback: docs-only change, safe to revert.

## Security & Data
- Documentation-only; no runtime/data impact.
