### PR TITLE
infra: dockerize portfolio web runtime image (closes #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This repository distills battle-tested patterns from real-world execution into p
 - Promotion checklist: `docs/release/promotion-checklist.md`
 - Rollback playbook: `docs/release/rollback-playbook.md`
 - Validation evidence: `docs/release/validation-evidence.md`
+- Local container runbook: `docs/deploy/local-container.md`
 
 ## License
 

--- a/docs/deploy/local-container.md
+++ b/docs/deploy/local-container.md
@@ -1,0 +1,17 @@
+# Local Container Build and Run
+
+## Build
+```bash
+docker build -f web/Dockerfile -t ghcr.io/neil795/neil-sinha-it-portfolio:local .
+```
+
+## Run
+```bash
+docker run --rm -p 8080:8080 ghcr.io/neil795/neil-sinha-it-portfolio:local
+```
+
+## Smoke check
+```bash
+curl -I http://127.0.0.1:8080/
+```
+Expected: `HTTP/1.1 200 OK`

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22-alpine AS build
+WORKDIR /app
+
+COPY web/package*.json ./
+RUN npm ci
+
+COPY web/ ./
+RUN npm run build
+
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
+WORKDIR /usr/share/nginx/html
+
+COPY --from=build /app/dist ./
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -q -O /dev/null http://127.0.0.1:8080/ || exit 1


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for web app build/runtime
- add repository dockerignore for leaner build context
- add local container build/run runbook
- link container runbook from README

## Why
Issue #26 requires an immutable runtime image for local cluster deployment and reproducible environment parity.

Closes #26

## Tests
- `docker build -f web/Dockerfile -t ghcr.io/neil795/neil-sinha-it-portfolio:local .`
- `docker run --rm -p 18080:8080 ghcr.io/neil795/neil-sinha-it-portfolio:local`
- `curl http://127.0.0.1:18080/` contains `Neil Sinha` (smoke pass)

## Risk & Rollback
- Risk: base image defaults may change upstream over time.
- Rollback: revert Dockerfile and runbook changes.

## Security & Data
- Runtime serves static assets only; non-root nginx-unprivileged base used.
