### PR TITLE
ci(container): add GHCR build/publish pipeline (closes #27)

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,58 @@
+name: Container Image
+
+on:
+  pull_request:
+    paths:
+      - 'web/**'
+      - '.github/workflows/container-image.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/container-image.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/neil795/neil-sinha-it-portfolio
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build (and push on main)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: web/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Job summary
+        run: |
+          echo "### Container image" >> $GITHUB_STEP_SUMMARY
+          echo "- Image: ghcr.io/neil795/neil-sinha-it-portfolio" >> $GITHUB_STEP_SUMMARY
+          echo "- Tags: ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This repository distills battle-tested patterns from real-world execution into p
 - Rollback playbook: `docs/release/rollback-playbook.md`
 - Validation evidence: `docs/release/validation-evidence.md`
 - Local container runbook: `docs/deploy/local-container.md`
+- Container build pipeline: `docs/deploy/container-pipeline.md`
 
 ## License
 

--- a/docs/deploy/container-pipeline.md
+++ b/docs/deploy/container-pipeline.md
@@ -1,0 +1,17 @@
+# Container Pipeline
+
+Workflow: `.github/workflows/container-image.yml`
+
+## Behavior
+- Pull requests: validate image build only (no push)
+- Main branch: build and push to GHCR
+- Manual dispatch: build and push to GHCR
+
+## Registry
+- Image: `ghcr.io/neil795/neil-sinha-it-portfolio`
+- Tags:
+  - `sha-<fullsha>`
+  - `latest` (main only)
+
+## Traceability
+Each image tag includes commit SHA and workflow summary output for audit linkage.


### PR DESCRIPTION
## Summary
- add `Container Image` workflow for Docker build/publish
- validate image builds on PRs (no push)
- publish GHCR image on main with long SHA tag and latest
- add pipeline docs and README references

## Why
Issue #27 requires automated container builds and traceable image publication for deployment workflows.

Closes #27

## Tests
- Workflow syntax validated in PR checks
- Pipeline behavior encoded by event type:
  - PR: build only
  - main/workflow_dispatch: build + push GHCR

## Risk & Rollback
- Risk: GHCR push depends on package permission policy.
- Rollback: revert workflow and pipeline docs.

## Security & Data
- Uses `GITHUB_TOKEN` package write scope; no application data-path changes.
