### PR TITLE
feat(ui): PR2 add SVG proof visuals and trust strip polish

### DIFF
--- a/web/public/assets/case-anz-flow.svg
+++ b/web/public/assets/case-anz-flow.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="180" viewBox="0 0 720 180" fill="none">
+  <rect width="720" height="180" rx="12" fill="#F8FAFC"/>
+  <rect x="28" y="40" width="180" height="42" rx="8" fill="#E2E8F0"/>
+  <text x="40" y="66" fill="#334155" font-family="Inter, Arial" font-size="14">Monorepo Build (18m)</text>
+  <rect x="262" y="40" width="180" height="42" rx="8" fill="#DBEAFE"/>
+  <text x="274" y="66" fill="#1E3A8A" font-family="Inter, Arial" font-size="14">Context-Aware Build</text>
+  <rect x="496" y="40" width="180" height="42" rx="8" fill="#DCFCE7"/>
+  <text x="508" y="66" fill="#166534" font-family="Inter, Arial" font-size="14">Optimized Build (3m)</text>
+  <path d="M216 61h36" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
+  <path d="M450 61h36" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="252" cy="61" r="3" fill="#64748B"/>
+  <circle cx="486" cy="61" r="3" fill="#64748B"/>
+  <text x="28" y="128" fill="#475569" font-family="Inter, Arial" font-size="13">Shift-left validation and Kafka automation reduced defects and manual checks.</text>
+</svg>

--- a/web/public/assets/case-chat-erp-governance.svg
+++ b/web/public/assets/case-chat-erp-governance.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="180" viewBox="0 0 720 180" fill="none">
+  <rect width="720" height="180" rx="12" fill="#F8FAFC"/>
+  <rect x="28" y="40" width="144" height="42" rx="8" fill="#FEE2E2"/>
+  <text x="40" y="66" fill="#7F1D1D" font-family="Inter, Arial" font-size="14">Ad hoc PR flow</text>
+  <rect x="220" y="40" width="144" height="42" rx="8" fill="#FEF3C7"/>
+  <text x="236" y="66" fill="#92400E" font-family="Inter, Arial" font-size="14">Issue-first gates</text>
+  <rect x="412" y="40" width="144" height="42" rx="8" fill="#DBEAFE"/>
+  <text x="426" y="66" fill="#1E3A8A" font-family="Inter, Arial" font-size="14">Proof bundle CI</text>
+  <rect x="584" y="40" width="108" height="42" rx="8" fill="#DCFCE7"/>
+  <text x="598" y="66" fill="#166534" font-family="Inter, Arial" font-size="14">Safe merge</text>
+  <path d="M180 61h28" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
+  <path d="M372 61h28" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
+  <path d="M564 61h14" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
+  <text x="28" y="128" fill="#475569" font-family="Inter, Arial" font-size="13">Governance becomes enforceable: issue link, scope checks, proof comment, and CI evidence required.</text>
+</svg>

--- a/web/public/assets/case-humanforce-flow.svg
+++ b/web/public/assets/case-humanforce-flow.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="180" viewBox="0 0 720 180" fill="none">
+  <rect width="720" height="180" rx="12" fill="#F8FAFC"/>
+  <rect x="28" y="40" width="180" height="42" rx="8" fill="#E2E8F0"/>
+  <text x="40" y="66" fill="#334155" font-family="Inter, Arial" font-size="14">Legacy CI + Long Tests</text>
+  <rect x="262" y="40" width="180" height="42" rx="8" fill="#DBEAFE"/>
+  <text x="278" y="66" fill="#1E3A8A" font-family="Inter, Arial" font-size="14">GitHub Actions</text>
+  <rect x="496" y="40" width="180" height="42" rx="8" fill="#DCFCE7"/>
+  <text x="508" y="66" fill="#166534" font-family="Inter, Arial" font-size="14">ECS/Fargate Test Grid</text>
+  <path d="M216 61h36" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
+  <path d="M450 61h36" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="252" cy="61" r="3" fill="#64748B"/>
+  <circle cx="486" cy="61" r="3" fill="#64748B"/>
+  <text x="28" y="128" fill="#475569" font-family="Inter, Arial" font-size="13">Result: ~40% fewer build failures and test duration reduced from 1 day to 1 hour.</text>
+</svg>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -19,6 +19,12 @@ const parseNumericToken = (value: string) => {
   return { num, prefix, suffix };
 };
 
+const caseVisualBySlug: Record<string, string> = {
+  'anz-platform-acceleration': '/assets/case-anz-flow.svg',
+  'humanforce-ci-reliability': '/assets/case-humanforce-flow.svg',
+  'chat-erp-governed-delivery': '/assets/case-chat-erp-governance.svg',
+};
+
 const meta = metaEntry?.data;
 ---
 
@@ -90,6 +96,9 @@ const meta = metaEntry?.data;
                 );
               })}
             </div>
+            {caseVisualBySlug[entry.data.slug] && (
+              <img class="case-visual" src={caseVisualBySlug[entry.data.slug]} alt={`Architecture summary for ${entry.data.title}`} loading="lazy" />
+            )}
             <p><strong>Problem:</strong> {entry.data.problem}</p>
             <p><strong>Intervention:</strong> {entry.data.intervention}</p>
             <p><strong>Tradeoff:</strong> {entry.data.tradeoffs}</p>
@@ -145,6 +154,12 @@ const meta = metaEntry?.data;
     <section id="trust" class="section" aria-labelledby="trust-title" data-section data-reveal>
       <h2 id="trust-title">Trust Layer</h2>
       <p class="subtitle">Delivery experience spans ANZ, Humanforce, mPrest, and Monash-led engineering environments with measurable operational outcomes.</p>
+      <div class="logo-strip" aria-label="Organizations and institutions">
+        <span>ANZ</span>
+        <span>Humanforce</span>
+        <span>mPrest</span>
+        <span>Monash</span>
+      </div>
     </section>
 
     <section id="contact" class="section section-inverse cta" aria-labelledby="contact-title" data-section data-reveal>
@@ -281,6 +296,7 @@ const meta = metaEntry?.data;
   .metric-block { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: .6rem .75rem; }
   .metric-value { margin: 0; font-size: 1.35rem; line-height: 1.2; color: var(--accent); font-weight: 700; font-variant-numeric: tabular-nums; }
   .metric-label { margin: .2rem 0 0; font-size: var(--text-xs); color: var(--text-muted); }
+  .case-visual { width: 100%; border: 1px solid var(--border-default); border-radius: var(--radius-md); background: var(--bg-primary); margin: .25rem 0 var(--space-md); }
 
   .governance-grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); gap: var(--space-md); }
   .governance-card { background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: var(--space-md); }
@@ -293,6 +309,17 @@ const meta = metaEntry?.data;
   .timeline-content p, .timeline-content li { color: var(--text-secondary); line-height: var(--leading-normal); }
 
   .elevated-block { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: var(--space-lg); }
+
+  .logo-strip { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-top: var(--space-md); }
+  .logo-strip span {
+    padding: .4rem .65rem;
+    border: 1px solid var(--border-default);
+    border-radius: 999px;
+    font-size: var(--text-small);
+    color: var(--text-secondary);
+    background: var(--bg-surface);
+    letter-spacing: 0.02em;
+  }
 
   .cta { margin-bottom: 0; }
   .cta-actions { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-top: var(--space-md); }


### PR DESCRIPTION
## Summary
- add lightweight custom SVG proof visuals for each case study
- integrate architecture visuals into case-study cards
- add trust strip for key organizations in trust layer
- keep asset footprint small and static (no gif/lottie overhead)

## Why
Issue #40 delivers PR2 of the interaction polish plan by adding credible visual proof artifacts and subtle trust cues without over-animation.

Closes #40

## Tests
- `cd web && npm run astro -- check`
- `cd web && npm run build`
- Result: pass (no errors; existing Astro hints only)

## Risk & Rollback
- Risk: copy/visual wording in SVGs may need iteration.
- Rollback: revert SVG assets + page integration.

## Security & Data
- Static frontend asset/content updates only; no data/auth impact.
