### PR TITLE
feat(ui): narrative-flow polish with full-content cards, subtle depth, and light/dark theme

### DIFF
--- a/web/src/components/SiteNav.astro
+++ b/web/src/components/SiteNav.astro
@@ -19,6 +19,9 @@ const items = [
         ))}
       </ul>
     </nav>
+    <button class="theme-toggle" type="button" aria-label="Toggle color theme" data-theme-toggle>
+      Theme
+    </button>
   </div>
   <div class="progress" aria-hidden="true"><span data-scroll-progress></span></div>
 </header>
@@ -53,6 +56,17 @@ const items = [
     text-decoration: none;
     letter-spacing: -0.01em;
   }
+
+  .theme-toggle {
+    border: 1px solid var(--border-default);
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    font-size: var(--text-small);
+    cursor: pointer;
+  }
+  .theme-toggle:hover { color: var(--text-primary); border-color: var(--border-strong); }
 
   ul { display: flex; gap: var(--space-lg); list-style: none; padding: 0; margin: 0; }
 

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -10,6 +10,13 @@
 	</head>
 	<body>
 		<slot />
+		<script>
+			const key = 'portfolio-theme';
+			const stored = localStorage.getItem(key);
+			const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+			const theme = stored || (prefersDark ? 'dark' : 'light');
+			document.documentElement.setAttribute('data-theme', theme);
+		</script>
 	</body>
 </html>
 
@@ -80,9 +87,32 @@
 		margin: 0;
 		width: 100%;
 		min-height: 100%;
-		background: radial-gradient(circle at 10% 0%, #eef2ff 0%, var(--bg-primary) 28%);
+		background: var(--bg-primary);
 		color: var(--text-primary);
 		font-family: var(--font-body);
+	}
+
+	body::before,
+	body::after {
+		content: '';
+		position: fixed;
+		inset: 0;
+		pointer-events: none;
+		z-index: -1;
+	}
+	body::before {
+		background:
+			radial-gradient(circle at 12% 10%, color-mix(in oklab, var(--accent) 10%, transparent), transparent 40%),
+			radial-gradient(circle at 88% 22%, color-mix(in oklab, var(--accent) 8%, transparent), transparent 42%),
+			linear-gradient(rgba(15, 23, 42, 0.03) 1px, transparent 1px),
+			linear-gradient(90deg, rgba(15, 23, 42, 0.03) 1px, transparent 1px);
+		background-size: auto, auto, 42px 42px, 42px 42px;
+		opacity: 0.35;
+	}
+	body::after {
+		background: radial-gradient(circle at 50% -20%, color-mix(in oklab, var(--accent) 12%, transparent), transparent 56%);
+		transform: translateY(calc(var(--scroll-y, 0px) * 0.04));
+		opacity: 0.4;
 	}
 
 	* { box-sizing: border-box; }
@@ -116,8 +146,32 @@
 		}
 	}
 
+	:root[data-theme='dark'] {
+		--bg-primary: #020617;
+		--bg-surface: #0b1220;
+		--bg-elevated: #111b2e;
+		--bg-inverse: #e2e8f0;
+		--bg-inverse-surface: #cbd5e1;
+
+		--text-primary: #e2e8f0;
+		--text-secondary: #cbd5e1;
+		--text-muted: #94a3b8;
+		--text-inverse: #0f172a;
+		--text-inverse-muted: #334155;
+
+		--border-default: #243247;
+		--border-strong: #334155;
+		--accent-subtle: #1e3a8a;
+
+		--shadow-sm: 0 1px 2px rgba(2, 6, 23, 0.45);
+		--shadow-md: 0 4px 12px rgba(2, 6, 23, 0.5);
+		--shadow-lg: 0 8px 24px rgba(2, 6, 23, 0.55);
+		--shadow-hover: 0 8px 24px rgba(2, 6, 23, 0.65);
+	}
+
 	@media (prefers-reduced-motion: reduce) {
 		* { scroll-behavior: auto !important; }
 		.reveal { opacity: 1; transform: none; animation: none; }
+		body::after { transform: none; }
 	}
 </style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -114,14 +114,11 @@ const meta = metaEntry?.data;
           <article class="dense-card">
             <h3>{entry.data.title}</h3>
             <p class="dense-kicker"><strong>Risk reduction:</strong> {entry.data.riskReduction}</p>
-            <details>
-              <summary>View controls</summary>
-              <ul>
-                <li><strong>Failure mode:</strong> {entry.data.failureMode}</li>
-                <li><strong>Blast radius:</strong> {entry.data.blastRadius}</li>
-                <li><strong>Guardrail:</strong> {entry.data.guardrailAdded}</li>
-              </ul>
-            </details>
+            <ul>
+              <li><strong>Failure mode:</strong> {entry.data.failureMode}</li>
+              <li class="secondary"><strong>Blast radius:</strong> {entry.data.blastRadius}</li>
+              <li class="secondary"><strong>Guardrail:</strong> {entry.data.guardrailAdded}</li>
+            </ul>
           </article>
         ))}
       </div>
@@ -136,16 +133,8 @@ const meta = metaEntry?.data;
             <h3>{entry.data.title}</h3>
             <p>{entry.data.summary}</p>
             <ul>
-              {entry.data.highlights.slice(0, 2).map((h) => <li>{h}</li>)}
+              {entry.data.highlights.map((h, idx) => <li class={idx > 1 ? 'secondary' : ''}>{h}</li>)}
             </ul>
-            {entry.data.highlights.length > 2 && (
-              <details>
-                <summary>More outcomes</summary>
-                <ul>
-                  {entry.data.highlights.slice(2).map((h) => <li>{h}</li>)}
-                </ul>
-              </details>
-            )}
           </article>
         ))}
       </div>
@@ -245,12 +234,27 @@ const meta = metaEntry?.data;
     sections.forEach((section) => navObserver.observe(section));
   }
 
+  const themeToggle = document.querySelector('[data-theme-toggle]');
+  const themeLabel = () => {
+    const current = document.documentElement.getAttribute('data-theme') || 'light';
+    if (themeToggle) themeToggle.textContent = current === 'dark' ? 'Dark' : 'Light';
+  };
+  themeLabel();
+  themeToggle?.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme') || 'light';
+    const next = current === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('portfolio-theme', next);
+    themeLabel();
+  });
+
   const updateProgress = () => {
     if (!progress) return;
     const scrollTop = window.scrollY;
     const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
     const pct = scrollHeight > 0 ? Math.min(100, Math.max(0, (scrollTop / scrollHeight) * 100)) : 0;
     progress.style.width = `${pct}%`;
+    document.documentElement.style.setProperty('--scroll-y', `${Math.min(8, scrollTop * 0.02)}px`);
   };
 
   updateProgress();
@@ -259,7 +263,17 @@ const meta = metaEntry?.data;
 
 <style>
   .page { max-width: 1100px; margin: 0 auto; padding: var(--space-xl) 1.25rem var(--space-3xl); }
-  .section { margin: 0 0 var(--space-section); scroll-margin-top: 96px; }
+  .section { margin: 0 0 var(--space-section); scroll-margin-top: 96px; position: relative; padding: var(--space-lg); border-radius: var(--radius-lg); }
+  .section:nth-of-type(even) { background: color-mix(in oklab, var(--bg-elevated) 72%, transparent); }
+  .section + .section::before {
+    content: '';
+    position: absolute;
+    left: 12%;
+    right: 12%;
+    top: calc(var(--space-section) * -0.5);
+    height: 1px;
+    background: linear-gradient(to right, transparent, var(--border-default), transparent);
+  }
   .eyebrow { font-size: var(--text-small); text-transform: uppercase; letter-spacing: .08em; color: var(--text-muted); }
   h1 { font-size: var(--text-hero); line-height: var(--leading-tight); max-width: 16ch; margin: var(--space-xs) 0 var(--space-md); }
   h2 { font-size: var(--text-section); margin-bottom: var(--space-lg); }
@@ -310,8 +324,7 @@ const meta = metaEntry?.data;
   .dense-card { background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: var(--space-md); }
   .dense-card p, .dense-card li { color: var(--text-secondary); line-height: var(--leading-normal); }
   .dense-card ul { margin: .5rem 0 0; padding-left: 1rem; }
-  .dense-card details { margin-top: .5rem; }
-  .dense-card summary { cursor: pointer; color: var(--accent); font-weight: 600; }
+  .dense-card li.secondary { opacity: 0.68; font-size: 0.96em; }
   .dense-kicker { margin: .2rem 0 .4rem; }
 
   .elevated-block { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: var(--space-lg); }


### PR DESCRIPTION
## Summary
- remove click-to-expand truncation pattern in post-case-study sections
- keep full content visible with layered emphasis (`secondary` bullets)
- add section rhythm via subtle divider lines and alternating section treatments
- add low-noise depth layers in page background + restrained background parallax
- add persistent light/dark theme toggle (localStorage + prefers-color-scheme)

## Why
Issue #44 addresses narrative drop-off and overly flat visual depth while preserving professionalism, readability, and performance.

Closes #44

## Tests
- `cd web && npm run astro -- check`
- `cd web && npm run build`
- Result: pass (no errors; existing Astro hints only)

## Risk & Rollback
- Risk: dark-mode token tuning may need one more contrast pass on specific displays.
- Rollback: revert layout/nav/index changes in this PR.

## Security & Data
- Frontend UI/theme behavior only; no auth/data changes.
