### PR TITLE
feat(ui): promote refined split-hero dark-mode visual system

### DIFF
--- a/web/public/assets/case-anz-flow.svg
+++ b/web/public/assets/case-anz-flow.svg
@@ -1,14 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="720" height="180" viewBox="0 0 720 180" fill="none">
-  <rect width="720" height="180" rx="12" fill="#F8FAFC"/>
-  <rect x="28" y="40" width="180" height="42" rx="8" fill="#E2E8F0"/>
-  <text x="40" y="66" fill="#334155" font-family="Inter, Arial" font-size="14">Monorepo Build (18m)</text>
-  <rect x="262" y="40" width="180" height="42" rx="8" fill="#DBEAFE"/>
-  <text x="274" y="66" fill="#1E3A8A" font-family="Inter, Arial" font-size="14">Context-Aware Build</text>
-  <rect x="496" y="40" width="180" height="42" rx="8" fill="#DCFCE7"/>
-  <text x="508" y="66" fill="#166534" font-family="Inter, Arial" font-size="14">Optimized Build (3m)</text>
-  <path d="M216 61h36" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
-  <path d="M450 61h36" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
-  <circle cx="252" cy="61" r="3" fill="#64748B"/>
-  <circle cx="486" cy="61" r="3" fill="#64748B"/>
-  <text x="28" y="128" fill="#475569" font-family="Inter, Arial" font-size="13">Shift-left validation and Kafka automation reduced defects and manual checks.</text>
+  <rect width="720" height="180" rx="12" fill="#0F172A"/>
+  <rect x="28" y="40" width="180" height="42" rx="8" fill="rgba(248,113,113,0.1)" stroke="rgba(248,113,113,0.3)"/>
+  <text x="40" y="66" fill="#F87171" font-family="Inter, Arial" font-size="14">Monorepo Build (18m)</text>
+  <rect x="262" y="40" width="180" height="42" rx="8" fill="rgba(59,130,246,0.15)" stroke="rgba(96,165,250,0.3)"/>
+  <text x="274" y="66" fill="#60A5FA" font-family="Inter, Arial" font-size="14">Context-Aware Build</text>
+  <rect x="496" y="40" width="180" height="42" rx="8" fill="rgba(52,211,153,0.1)" stroke="rgba(52,211,153,0.3)"/>
+  <text x="508" y="66" fill="#34D399" font-family="Inter, Arial" font-size="14">Optimized Build (3m)</text>
+  <path d="M216 61h36" stroke="rgba(148,163,184,0.2)" stroke-width="2" stroke-linecap="round"/>
+  <path d="M450 61h36" stroke="rgba(148,163,184,0.2)" stroke-width="2" stroke-linecap="round"/>
+  <text x="28" y="128" fill="#94A3B8" font-family="Inter, Arial" font-size="13">Shift-left validation and Kafka automation reduced defects and manual checks.</text>
 </svg>

--- a/web/public/assets/case-chat-erp-governance.svg
+++ b/web/public/assets/case-chat-erp-governance.svg
@@ -1,15 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="720" height="180" viewBox="0 0 720 180" fill="none">
-  <rect width="720" height="180" rx="12" fill="#F8FAFC"/>
-  <rect x="28" y="40" width="144" height="42" rx="8" fill="#FEE2E2"/>
-  <text x="40" y="66" fill="#7F1D1D" font-family="Inter, Arial" font-size="14">Ad hoc PR flow</text>
-  <rect x="220" y="40" width="144" height="42" rx="8" fill="#FEF3C7"/>
-  <text x="236" y="66" fill="#92400E" font-family="Inter, Arial" font-size="14">Issue-first gates</text>
-  <rect x="412" y="40" width="144" height="42" rx="8" fill="#DBEAFE"/>
-  <text x="426" y="66" fill="#1E3A8A" font-family="Inter, Arial" font-size="14">Proof bundle CI</text>
-  <rect x="584" y="40" width="108" height="42" rx="8" fill="#DCFCE7"/>
-  <text x="598" y="66" fill="#166534" font-family="Inter, Arial" font-size="14">Safe merge</text>
-  <path d="M180 61h28" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
-  <path d="M372 61h28" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
-  <path d="M564 61h14" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
-  <text x="28" y="128" fill="#475569" font-family="Inter, Arial" font-size="13">Governance becomes enforceable: issue link, scope checks, proof comment, and CI evidence required.</text>
+  <rect width="720" height="180" rx="12" fill="#0F172A"/>
+  <rect x="28" y="40" width="144" height="42" rx="8" fill="rgba(248,113,113,0.1)" stroke="rgba(248,113,113,0.3)"/>
+  <text x="40" y="66" fill="#F87171" font-family="Inter, Arial" font-size="14">Ad hoc PR flow</text>
+  <rect x="220" y="40" width="144" height="42" rx="8" fill="rgba(59,130,246,0.15)" stroke="rgba(96,165,250,0.3)"/>
+  <text x="236" y="66" fill="#60A5FA" font-family="Inter, Arial" font-size="14">Issue-first gates</text>
+  <rect x="412" y="40" width="144" height="42" rx="8" fill="rgba(59,130,246,0.15)" stroke="rgba(96,165,250,0.3)"/>
+  <text x="426" y="66" fill="#60A5FA" font-family="Inter, Arial" font-size="14">Proof bundle CI</text>
+  <rect x="584" y="40" width="108" height="42" rx="8" fill="rgba(52,211,153,0.1)" stroke="rgba(52,211,153,0.3)"/>
+  <text x="598" y="66" fill="#34D399" font-family="Inter, Arial" font-size="14">Safe merge</text>
+  <path d="M180 61h28" stroke="rgba(148,163,184,0.2)" stroke-width="2" stroke-linecap="round"/>
+  <path d="M372 61h28" stroke="rgba(148,163,184,0.2)" stroke-width="2" stroke-linecap="round"/>
+  <path d="M564 61h14" stroke="rgba(148,163,184,0.2)" stroke-width="2" stroke-linecap="round"/>
+  <text x="28" y="128" fill="#94A3B8" font-family="Inter, Arial" font-size="13">Governance becomes enforceable: issue link, scope checks, proof comment, and CI evidence required.</text>
 </svg>

--- a/web/public/assets/case-humanforce-flow.svg
+++ b/web/public/assets/case-humanforce-flow.svg
@@ -1,14 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="720" height="180" viewBox="0 0 720 180" fill="none">
-  <rect width="720" height="180" rx="12" fill="#F8FAFC"/>
-  <rect x="28" y="40" width="180" height="42" rx="8" fill="#E2E8F0"/>
-  <text x="40" y="66" fill="#334155" font-family="Inter, Arial" font-size="14">Legacy CI + Long Tests</text>
-  <rect x="262" y="40" width="180" height="42" rx="8" fill="#DBEAFE"/>
-  <text x="278" y="66" fill="#1E3A8A" font-family="Inter, Arial" font-size="14">GitHub Actions</text>
-  <rect x="496" y="40" width="180" height="42" rx="8" fill="#DCFCE7"/>
-  <text x="508" y="66" fill="#166534" font-family="Inter, Arial" font-size="14">ECS/Fargate Test Grid</text>
-  <path d="M216 61h36" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
-  <path d="M450 61h36" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
-  <circle cx="252" cy="61" r="3" fill="#64748B"/>
-  <circle cx="486" cy="61" r="3" fill="#64748B"/>
-  <text x="28" y="128" fill="#475569" font-family="Inter, Arial" font-size="13">Result: ~40% fewer build failures and test duration reduced from 1 day to 1 hour.</text>
+  <rect width="720" height="180" rx="12" fill="#0F172A"/>
+  <rect x="28" y="40" width="180" height="42" rx="8" fill="rgba(248,113,113,0.1)" stroke="rgba(248,113,113,0.3)"/>
+  <text x="40" y="66" fill="#F87171" font-family="Inter, Arial" font-size="14">Legacy CI + Long Tests</text>
+  <rect x="262" y="40" width="180" height="42" rx="8" fill="rgba(59,130,246,0.15)" stroke="rgba(96,165,250,0.3)"/>
+  <text x="278" y="66" fill="#60A5FA" font-family="Inter, Arial" font-size="14">GitHub Actions</text>
+  <rect x="496" y="40" width="180" height="42" rx="8" fill="rgba(52,211,153,0.1)" stroke="rgba(52,211,153,0.3)"/>
+  <text x="508" y="66" fill="#34D399" font-family="Inter, Arial" font-size="14">ECS/Fargate Test Grid</text>
+  <path d="M216 61h36" stroke="rgba(148,163,184,0.2)" stroke-width="2" stroke-linecap="round"/>
+  <path d="M450 61h36" stroke="rgba(148,163,184,0.2)" stroke-width="2" stroke-linecap="round"/>
+  <text x="28" y="128" fill="#94A3B8" font-family="Inter, Arial" font-size="13">Result: ~40% fewer build failures and test duration reduced from 1 day to 1 hour.</text>
 </svg>

--- a/web/src/components/SiteNav.astro
+++ b/web/src/components/SiteNav.astro
@@ -4,24 +4,21 @@ const items = [
   { href: '#ai-governance', label: 'AI Risk' },
   { href: '#experience', label: 'Experience' },
   { href: '#web-foundry', label: 'Web Foundry' },
-  { href: '#contact', label: 'Contact' },
+  { href: '#contact', label: 'Contact', cta: true },
 ];
 ---
 
-<a class="skip-link" href="#main-content">Skip to content</a>
+<a href="#main-content" class="skip-link">Skip to content</a>
 <header class="site-header" role="banner">
   <div class="container nav-wrap">
     <a class="brand" href="#hero">Neil Sinha</a>
     <nav aria-label="Primary">
       <ul>
         {items.map((item) => (
-          <li><a href={item.href} data-navlink>{item.label}</a></li>
+          <li><a href={item.href} data-navlink class={item.cta ? 'is-cta' : ''}>{item.label}</a></li>
         ))}
       </ul>
     </nav>
-    <button class="theme-toggle" type="button" aria-label="Toggle color theme" data-theme-toggle>
-      Theme
-    </button>
   </div>
   <div class="progress" aria-hidden="true"><span data-scroll-progress></span></div>
 </header>
@@ -31,9 +28,9 @@ const items = [
     position: absolute;
     left: -9999px;
     top: 0;
-    background: var(--bg-inverse);
-    color: var(--text-inverse);
-    padding: var(--space-xs) var(--space-sm);
+    background: var(--accent);
+    color: var(--text-primary);
+    padding: var(--space-sm) var(--space-md);
     z-index: 100;
   }
   .skip-link:focus { left: 0.75rem; top: 0.75rem; }
@@ -42,56 +39,55 @@ const items = [
     position: sticky;
     top: 0;
     z-index: 50;
-    backdrop-filter: blur(8px);
-    background: color-mix(in oklab, var(--bg-surface) 90%, var(--bg-elevated) 10%);
-    border-bottom: 1px solid var(--border-default);
+    height: var(--nav-height);
+    backdrop-filter: blur(12px);
+    background: rgba(11, 15, 26, 0.85);
+    border-bottom: 1px solid var(--border-subtle);
   }
 
-  .container { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
-  .nav-wrap { min-height: 66px; display: flex; align-items: center; justify-content: space-between; gap: var(--space-lg); }
+  .container { max-width: var(--content-wide-max-width); margin: 0 auto; padding: 0 1.25rem; }
+  .nav-wrap { min-height: calc(var(--nav-height) - 2px); display: flex; align-items: center; justify-content: space-between; gap: var(--space-lg); }
 
   .brand {
+    font-family: var(--font-heading);
     font-weight: 700;
     color: var(--text-primary);
     text-decoration: none;
-    letter-spacing: -0.01em;
   }
 
-  .theme-toggle {
-    border: 1px solid var(--border-default);
-    background: var(--bg-elevated);
-    color: var(--text-secondary);
-    border-radius: 999px;
-    padding: 0.35rem 0.75rem;
-    font-size: var(--text-small);
-    cursor: pointer;
-  }
-  .theme-toggle:hover { color: var(--text-primary); border-color: var(--border-strong); }
-
-  ul { display: flex; gap: var(--space-lg); list-style: none; padding: 0; margin: 0; }
+  ul { display: flex; gap: var(--space-lg); list-style: none; padding: 0; margin: 0; align-items: center; }
 
   a {
     color: var(--text-secondary);
     text-decoration: none;
     font-size: var(--text-small);
-    line-height: var(--leading-normal);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    border-bottom: 2px solid transparent;
+    padding-bottom: 4px;
+    transition: all var(--duration-normal) var(--ease-out);
   }
 
   a:hover,
   a:focus-visible,
   a[aria-current='true'] {
     color: var(--text-primary);
-    text-decoration: underline;
-    text-decoration-color: color-mix(in oklab, var(--accent) 72%, transparent);
-    text-underline-offset: 0.18em;
+    border-bottom-color: var(--accent);
   }
 
-  .progress {
-    height: 2px;
-    width: 100%;
-    background: transparent;
+  a.is-cta {
+    border: 1px solid var(--border-medium);
+    border-radius: var(--radius-sm);
+    padding: var(--space-xs) var(--space-md);
+  }
+  a.is-cta:hover,
+  a.is-cta:focus-visible,
+  a.is-cta[aria-current='true'] {
+    border-color: var(--border-accent);
+    background: var(--accent-glow);
   }
 
+  .progress { height: 2px; width: 100%; background: transparent; }
   .progress > span {
     display: block;
     width: 0%;
@@ -101,6 +97,7 @@ const items = [
   }
 
   @media (max-width: 760px) {
+    .site-header { height: auto; }
     .nav-wrap { flex-direction: column; align-items: flex-start; padding: 0.75rem 1.25rem; }
     ul { flex-wrap: wrap; gap: 0.75rem; }
   }

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -11,167 +11,204 @@
 	<body>
 		<slot />
 		<script>
-			const key = 'portfolio-theme';
-			const stored = localStorage.getItem(key);
-			const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-			const theme = stored || (prefersDark ? 'dark' : 'light');
-			document.documentElement.setAttribute('data-theme', theme);
+			// @ts-nocheck
+			const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+			const revealEls = [...document.querySelectorAll('[data-reveal]')];
+			const countEls = [...document.querySelectorAll('[data-count-to]')];
+			const sectionEls = [...document.querySelectorAll('section[data-section]')];
+			const navLinks = [...document.querySelectorAll('[data-navlink]')];
+			const progress = document.querySelector('[data-scroll-progress]');
+
+			const setActive = (id) => {
+				navLinks.forEach((link) => {
+					const active = link.getAttribute('href') === `#${id}`;
+					if (active) link.setAttribute('aria-current', 'true');
+					else link.removeAttribute('aria-current');
+				});
+			};
+
+			const easeOutExpo = (x) => (x === 1 ? 1 : 1 - Math.pow(2, -10 * x));
+			const animateCount = (el) => {
+				if (el.dataset.counted === 'true' || reducedMotion) return;
+				const from = Number(el.dataset.countFrom ?? 0);
+				const to = Number(el.dataset.countTo ?? 0);
+				const duration = 1200;
+				const start = performance.now();
+				const step = (now) => {
+					const t = Math.min(1, (now - start) / duration);
+					const eased = easeOutExpo(t);
+					const value = from + (to - from) * eased;
+					el.textContent = `${Math.round(value)}`;
+					if (t < 1) requestAnimationFrame(step);
+					else {
+						el.textContent = `${to}`;
+						el.dataset.counted = 'true';
+					}
+				};
+				requestAnimationFrame(step);
+			};
+
+			const updateProgress = () => {
+				if (!progress) return;
+				const scrollTop = window.scrollY;
+				const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+				const pct = scrollHeight > 0 ? Math.min(100, Math.max(0, (scrollTop / scrollHeight) * 100)) : 0;
+				progress.style.width = `${pct}%`;
+			};
+
+			if (reducedMotion) {
+				revealEls.forEach((el) => el.setAttribute('data-visible', 'true'));
+			} else {
+				const observer = new IntersectionObserver((entries) => {
+					entries.forEach((entry) => {
+						if (!entry.isIntersecting) return;
+						entry.target.setAttribute('data-visible', 'true');
+						if (entry.target.hasAttribute('data-count-to')) animateCount(entry.target);
+						observer.unobserve(entry.target);
+					});
+				}, { threshold: 0.15, rootMargin: '0px 0px -50px 0px' });
+
+				revealEls.forEach((el) => observer.observe(el));
+				countEls.forEach((el) => observer.observe(el));
+			}
+
+			if (sectionEls.length > 0) {
+				const navObserver = new IntersectionObserver((entries) => {
+					const visible = entries.filter((e) => e.isIntersecting).sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+					if (visible?.target?.id) setActive(visible.target.id);
+				}, { threshold: [0.2, 0.5, 0.75] });
+				sectionEls.forEach((section) => navObserver.observe(section));
+			}
+
+			updateProgress();
+			window.addEventListener('scroll', updateProgress, { passive: true });
 		</script>
 	</body>
 </html>
 
 <style is:global>
 	:root {
-		--bg-primary: #f8fafc;
-		--bg-surface: #ffffff;
-		--bg-elevated: #f1f5f9;
-		--bg-inverse: #0f172a;
-		--bg-inverse-surface: #1e293b;
+		--bg-deep: #0B0F1A;
+		--bg-primary: #0F172A;
+		--bg-elevated: #1E293B;
+		--bg-surface: #1A2332;
 
-		--text-primary: #0f172a;
-		--text-secondary: #334155;
-		--text-muted: #64748b;
-		--text-inverse: #f8fafc;
-		--text-inverse-muted: #94a3b8;
+		--text-primary: #F1F5F9;
+		--text-secondary: #94A3B8;
+		--text-muted: #64748B;
+		--text-accent: #60A5FA;
 
-		--border-default: #e2e8f0;
-		--border-strong: #cbd5e1;
+		--border-subtle: rgba(148, 163, 184, 0.1);
+		--border-medium: rgba(148, 163, 184, 0.2);
+		--border-accent: rgba(96, 165, 250, 0.3);
 
-		--accent: #2563eb;
-		--accent-subtle: #dbeafe;
+		--accent: #3B82F6;
+		--accent-glow: rgba(59, 130, 246, 0.15);
 
-		--severity-high: #dc2626;
-		--severity-medium: #d97706;
-		--severity-low: #16a34a;
+		--severity-high: #F87171;
+		--severity-medium: #FBBF24;
+		--severity-resolved: #34D399;
 
 		--font-heading: 'Inter Tight', 'Inter', system-ui, -apple-system, sans-serif;
 		--font-body: 'Inter', system-ui, -apple-system, sans-serif;
+		--font-mono: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
 
-		--text-hero: clamp(3rem, 5vw, 3.5rem);
-		--text-section: clamp(2rem, 3.5vw, 2.25rem);
-		--text-card-title: clamp(1.2rem, 2.2vw, 1.375rem);
+		--text-hero: clamp(2.5rem, 5vw, 3.5rem);
+		--text-section: clamp(1.75rem, 3vw, 2.25rem);
+		--text-card-title: 1.25rem;
+		--text-stat: clamp(1.5rem, 3vw, 2rem);
 		--text-body: 1rem;
 		--text-small: 0.875rem;
 		--text-xs: 0.75rem;
+		--text-label: 0.6875rem;
 
-		--leading-tight: 1.15;
+		--leading-tight: 1.2;
 		--leading-normal: 1.6;
 
-		--space-2xs: 0.25rem;
-		--space-xs: 0.5rem;
-		--space-sm: 0.75rem;
+		--tracking-tight: -0.02em;
+		--tracking-normal: 0;
+		--tracking-wide: 0.05em;
+		--tracking-widest: 0.1em;
+
+		--space-xs: 0.25rem;
+		--space-sm: 0.5rem;
 		--space-md: 1rem;
 		--space-lg: 1.5rem;
 		--space-xl: 2rem;
 		--space-2xl: 3rem;
 		--space-3xl: 4rem;
-		--space-section: clamp(5rem, 9vw, 7rem);
+		--space-section: 6rem;
+		--space-section-inner: 2.5rem;
 
 		--radius-sm: 6px;
 		--radius-md: 10px;
 		--radius-lg: 16px;
+		--radius-xl: 20px;
 
-		--shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04);
-		--shadow-md: 0 4px 12px rgba(15, 23, 42, 0.06);
-		--shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.08);
-		--shadow-hover: 0 8px 24px rgba(15, 23, 42, 0.12);
+		--shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 0 1px var(--border-subtle);
+		--shadow-card-hover: 0 4px 16px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--border-medium);
+		--shadow-elevated: 0 8px 32px rgba(0, 0, 0, 0.5);
 
 		--duration-fast: 150ms;
 		--duration-normal: 250ms;
 		--duration-slow: 400ms;
 		--ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+		--ease-in-out: cubic-bezier(0.45, 0, 0.55, 1);
+
+		--content-max-width: 960px;
+		--content-wide-max-width: 1100px;
+		--nav-height: 64px;
 	}
 
-	html,
+	html { scroll-behavior: smooth; scroll-padding-top: var(--nav-height); }
 	body {
 		margin: 0;
 		width: 100%;
 		min-height: 100%;
-		background: var(--bg-primary);
+		background-color: var(--bg-primary);
 		color: var(--text-primary);
 		font-family: var(--font-body);
+		font-size: var(--text-body);
+		line-height: var(--leading-normal);
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
 	}
-
-	body::before,
-	body::after {
-		content: '';
-		position: fixed;
-		inset: 0;
-		pointer-events: none;
-		z-index: -1;
-	}
-	body::before {
-		background:
-			radial-gradient(circle at 12% 10%, color-mix(in oklab, var(--accent) 10%, transparent), transparent 40%),
-			radial-gradient(circle at 88% 22%, color-mix(in oklab, var(--accent) 8%, transparent), transparent 42%),
-			linear-gradient(rgba(15, 23, 42, 0.03) 1px, transparent 1px),
-			linear-gradient(90deg, rgba(15, 23, 42, 0.03) 1px, transparent 1px);
-		background-size: auto, auto, 42px 42px, 42px 42px;
-		opacity: 0.35;
-	}
-	body::after {
-		background: radial-gradient(circle at 50% -20%, color-mix(in oklab, var(--accent) 12%, transparent), transparent 56%);
-		transform: translateY(calc(var(--scroll-y, 0px) * 0.04));
-		opacity: 0.4;
-	}
-
 	* { box-sizing: border-box; }
 
-	h1,
-	h2,
-	h3,
-	h4 {
+	h1, h2, h3, h4 {
 		font-family: var(--font-heading);
-		letter-spacing: -0.01em;
+		letter-spacing: var(--tracking-tight);
 	}
 
 	:focus-visible {
 		outline: 2px solid var(--accent);
 		outline-offset: 2px;
-		border-radius: var(--radius-sm);
+		border-radius: 2px;
 	}
 
-	.reveal {
+	[data-reveal] {
 		opacity: 0;
-		transform: translateY(8px);
-		animation: reveal var(--duration-slow) var(--ease-out) forwards;
+		transform: translateY(20px);
+		transition: opacity var(--duration-slow) var(--ease-out), transform var(--duration-slow) var(--ease-out);
 	}
-	.reveal.d2 { animation-delay: 120ms; }
-	.reveal.d3 { animation-delay: 200ms; }
-
-	@keyframes reveal {
-		to {
-			opacity: 1;
-			transform: translateY(0);
-		}
+	[data-reveal][data-visible] {
+		opacity: 1;
+		transform: translateY(0);
 	}
+	[data-reveal-stagger] > [data-reveal]:nth-child(1) { transition-delay: 0ms; }
+	[data-reveal-stagger] > [data-reveal]:nth-child(2) { transition-delay: 80ms; }
+	[data-reveal-stagger] > [data-reveal]:nth-child(3) { transition-delay: 160ms; }
+	[data-reveal-stagger] > [data-reveal]:nth-child(4) { transition-delay: 240ms; }
 
-	:root[data-theme='dark'] {
-		--bg-primary: #020617;
-		--bg-surface: #0b1220;
-		--bg-elevated: #111b2e;
-		--bg-inverse: #e2e8f0;
-		--bg-inverse-surface: #cbd5e1;
-
-		--text-primary: #e2e8f0;
-		--text-secondary: #cbd5e1;
-		--text-muted: #94a3b8;
-		--text-inverse: #0f172a;
-		--text-inverse-muted: #334155;
-
-		--border-default: #243247;
-		--border-strong: #334155;
-		--accent-subtle: #1e3a8a;
-
-		--shadow-sm: 0 1px 2px rgba(2, 6, 23, 0.45);
-		--shadow-md: 0 4px 12px rgba(2, 6, 23, 0.5);
-		--shadow-lg: 0 8px 24px rgba(2, 6, 23, 0.55);
-		--shadow-hover: 0 8px 24px rgba(2, 6, 23, 0.65);
-	}
+	[data-count-to] { font-variant-numeric: tabular-nums; }
 
 	@media (prefers-reduced-motion: reduce) {
-		* { scroll-behavior: auto !important; }
-		.reveal { opacity: 1; transform: none; animation: none; }
-		body::after { transform: none; }
+		*, *::before, *::after {
+			animation-duration: 0.01ms !important;
+			animation-iteration-count: 1 !important;
+			transition-duration: 0.01ms !important;
+		}
+		html { scroll-behavior: auto; }
+		[data-reveal] { opacity: 1; transform: none; transition: none; }
 	}
 </style>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -8,21 +8,17 @@ const caseStudies = (await getCollection('case-studies')).sort((a, b) => a.data.
 const experience = (await getCollection('experience')).sort((a, b) => a.data.order - b.data.order);
 const aiGovernance = (await getCollection('ai-governance')).sort((a, b) => a.data.order - b.data.order);
 
-const parseNumericToken = (value: string) => {
-  const match = value.match(/-?\d+(?:\.\d+)?/);
-  if (!match) return null;
-  const full = match[0];
-  const num = Number(full);
-  const index = value.indexOf(full);
-  const prefix = value.slice(0, index);
-  const suffix = value.slice(index + full.length);
-  return { num, prefix, suffix };
-};
-
 const caseVisualBySlug: Record<string, string> = {
   'anz-platform-acceleration': '/assets/case-anz-flow.svg',
   'humanforce-ci-reliability': '/assets/case-humanforce-flow.svg',
   'chat-erp-governed-delivery': '/assets/case-chat-erp-governance.svg',
+};
+
+const countMetaByLabel: Record<string, { from: number; to: number }> = {
+  'Monorepo build duration': { from: 18, to: 3 },
+  'Production defects': { from: 0, to: 37 },
+  'Manual streaming validation': { from: 0, to: 60 },
+  'Build failures': { from: 0, to: 40 },
 };
 
 const meta = metaEntry?.data;
@@ -30,11 +26,11 @@ const meta = metaEntry?.data;
 
 <Layout>
   <SiteNav />
-  <main id="main-content" class="page">
-    <section id="hero" class="section hero hero-split" aria-labelledby="hero-title" data-section>
-      <div class="hero-panels" aria-label="Platform and Data identity">
-        <article class="hero-panel hero-panel-platform" data-hero-side="platform" tabindex="0">
-          <p class="hero-panel-label">Platform / DevOps</p>
+  <main id="main-content">
+    <section id="hero" class="hero-split" data-section>
+      <div class="hero-panels">
+        <article class="hero-panel hero-panel-platform">
+          <p class="hero-label">PLATFORM / DEVOPS</p>
           <h2>I break things less.</h2>
           <ul>
             <li>Delivery discipline</li>
@@ -42,8 +38,8 @@ const meta = metaEntry?.data;
             <li>Cloud cost control</li>
           </ul>
         </article>
-        <article class="hero-panel hero-panel-data" data-hero-side="data" tabindex="0">
-          <p class="hero-panel-label">Data / AI Systems</p>
+        <article class="hero-panel hero-panel-data">
+          <p class="hero-label hero-label-accent">DATA / AI SYSTEMS</p>
           <h2>I make systems smarter.</h2>
           <ul>
             <li>Streaming pipelines</li>
@@ -52,11 +48,14 @@ const meta = metaEntry?.data;
           </ul>
         </article>
       </div>
-      <div class="hero-unified">
-        <p class="eyebrow">Neil Sinha · Platform + AI Engineering</p>
-        <h1 id="hero-title">I design systems that are both reliable and adaptive.</h1>
+    </section>
+
+    <section class="hero-unified" data-section>
+      <div class="container-narrow">
+        <p class="eyebrow">NEIL SINHA · PLATFORM + AI ENGINEERING</p>
+        <h1>I design systems that are both reliable and adaptive.</h1>
         <p class="subtitle">{meta?.heroSubtitle}</p>
-        <div class="proof-pills" aria-label="Outcome highlights">
+        <div class="proof-pills" aria-label="Outcome highlights" data-reveal-stagger>
           <span data-reveal>83% faster build cycles</span>
           <span data-reveal>−40% CI build failures</span>
           <span data-reveal>RTO 8h → 4h</span>
@@ -64,357 +63,265 @@ const meta = metaEntry?.data;
       </div>
     </section>
 
-    <section id="problem-landscape" class="section" aria-labelledby="problem-title" data-section data-reveal>
-      <h2 id="problem-title">Problem Landscape</h2>
-      <div class="problem-grid" data-reveal-stagger>
-        <article>
-          <p class="stat"><span data-count-up data-count-from="0" data-count-to="32">32</span>%</p>
-          <p>Cloud spend routinely wasted without active controls.</p>
-        </article>
-        <article>
-          <p class="stat"><span data-count-up data-count-from="0" data-count-to="1">1</span> in 5</p>
-          <p>Deployments fail in teams lacking CI reliability discipline.</p>
-        </article>
-        <article>
-          <p class="stat">High</p>
-          <p>AI-assisted delivery risk rises when governance is ad hoc.</p>
-        </article>
-      </div>
-    </section>
-
-    <section id="operating-philosophy" class="section" aria-labelledby="philosophy-title" data-section data-reveal>
-      <h2 id="philosophy-title">Operating Philosophy</h2>
-      <div class="philosophy-grid" data-reveal-stagger>
-        <article class="flat-block"><h3>Cost Discipline</h3><p>Engineer systems so spend stays forecastable and tied to outcomes.</p></article>
-        <article class="flat-block"><h3>Reliability First</h3><p>Prioritize repeatability and recovery over brittle delivery speed.</p></article>
-        <article class="flat-block"><h3>Observability</h3><p>Surface health and latency signals early so failures are predictable.</p></article>
-        <article class="flat-block"><h3>Safe AI Adoption</h3><p>Acceleration only counts when controls and auditability stay intact.</p></article>
-      </div>
-    </section>
-
-    <section id="case-studies" class="section" aria-labelledby="case-studies-title" data-section data-reveal>
-      <h2 id="case-studies-title">Case Studies</h2>
-      <div class="case-list" data-reveal-stagger>
-        {caseStudies.map((entry) => (
-          <article class="case-card">
-            <p class="case-context">{entry.data.companyContext}</p>
-            <h3>{entry.data.title}</h3>
-            <div class="metric-row">
-              {entry.data.impact.slice(0, 3).map((metric) => {
-                const parsed = parseNumericToken(metric.after);
-                return (
-                  <div class="metric-block" aria-label={`${metric.label} changed from ${metric.before} to ${metric.after}`}>
-                    <p class="metric-value">
-                      {metric.before} → {parsed ? (
-                        <>
-                          {parsed.prefix}
-                          <span data-count-up data-count-from={parsed.num < 0 ? 0 : Math.max(0, Math.floor(parsed.num * 2))} data-count-to={parsed.num}>{parsed.num}</span>
-                          {parsed.suffix}
-                        </>
-                      ) : metric.after}
-                    </p>
-                    <p class="metric-label">{metric.label}</p>
-                  </div>
-                );
-              })}
-            </div>
-            {caseVisualBySlug[entry.data.slug] && (
-              <img class="case-visual" src={caseVisualBySlug[entry.data.slug]} alt={`Architecture summary for ${entry.data.title}`} loading="lazy" />
-            )}
-            <p><strong>Problem:</strong> {entry.data.problem}</p>
-            <p><strong>Intervention:</strong> {entry.data.intervention}</p>
-            <p><strong>Tradeoff:</strong> {entry.data.tradeoffs}</p>
+    <section id="problem-landscape" class="section section-deep" aria-labelledby="problem-title" data-section>
+      <div class="container-narrow">
+        <h2 id="problem-title" data-reveal>Problem Landscape</h2>
+        <div class="problem-grid" data-reveal-stagger>
+          <article data-reveal>
+            <p class="stat"><span data-count-from="0" data-count-to="32">32</span>%</p>
+            <p>Cloud spend routinely wasted without active controls.</p>
           </article>
-        ))}
-      </div>
-    </section>
-
-    <section id="ai-governance" class="section" aria-labelledby="governance-title" data-section data-reveal>
-      <h2 id="governance-title">AI Governance in Practice</h2>
-      <div class="compact-grid" data-reveal-stagger>
-        {aiGovernance.map((entry) => (
-          <article class="dense-card">
-            <h3>{entry.data.title}</h3>
-            <p class="dense-kicker"><strong>Risk reduction:</strong> {entry.data.riskReduction}</p>
-            <ul>
-              <li><strong>Failure mode:</strong> {entry.data.failureMode}</li>
-              <li class="secondary"><strong>Blast radius:</strong> {entry.data.blastRadius}</li>
-              <li class="secondary"><strong>Guardrail:</strong> {entry.data.guardrailAdded}</li>
-            </ul>
+          <article data-reveal>
+            <p class="stat"><span data-count-from="0" data-count-to="1">1</span> in 5</p>
+            <p>Deployments fail in teams lacking CI reliability discipline.</p>
           </article>
-        ))}
-      </div>
-    </section>
-
-    <section id="experience" class="section" aria-labelledby="experience-title" data-section data-reveal>
-      <h2 id="experience-title">Experience</h2>
-      <div class="compact-grid" data-reveal-stagger>
-        {experience.map((entry) => (
-          <article class="dense-card">
-            <p class="muted">{entry.data.period} · {entry.data.company}</p>
-            <h3>{entry.data.title}</h3>
-            <p>{entry.data.summary}</p>
-            <ul>
-              {entry.data.highlights.map((h, idx) => <li class={idx > 1 ? 'secondary' : ''}>{h}</li>)}
-            </ul>
+          <article data-reveal>
+            <p class="stat">High</p>
+            <p>AI-assisted delivery risk rises when governance is ad hoc.</p>
           </article>
-        ))}
+        </div>
       </div>
     </section>
 
-    <section id="web-foundry" class="section" aria-labelledby="web-foundry-title" data-section data-reveal>
-      <h2 id="web-foundry-title">Web Foundry</h2>
-      <article class="elevated-block">
-        <p>Operator-led consulting across platform modernization, cost governance, and release reliability for delivery-focused teams.</p>
-        <div class="tag-row"><span>Cloud Cost Control</span><span>CI/CD Reliability</span><span>AI Governance Controls</span></div>
-      </article>
-    </section>
-
-    <section id="trust" class="section" aria-labelledby="trust-title" data-section data-reveal>
-      <h2 id="trust-title">Trust Layer</h2>
-      <p class="subtitle">Trusted across enterprise, scale-up, and research environments with measured delivery outcomes.</p>
-      <div class="logo-strip" aria-label="Organizations and institutions">
-        <span>ANZ</span>
-        <span>Humanforce</span>
-        <span>mPrest</span>
-        <span>Monash</span>
+    <section id="operating-philosophy" class="section section-primary" aria-labelledby="philosophy-title" data-section>
+      <div class="container-narrow">
+        <h2 id="philosophy-title" data-reveal>Operating Philosophy</h2>
+        <div class="philosophy-grid" data-reveal-stagger>
+          <article class="flat-block" data-reveal><h3>Cost Discipline</h3><p>Engineer systems so spend stays forecastable and tied to outcomes.</p></article>
+          <article class="flat-block" data-reveal><h3>Reliability First</h3><p>Prioritize repeatability and recovery over brittle delivery speed.</p></article>
+          <article class="flat-block" data-reveal><h3>Observability</h3><p>Surface health and latency signals early so failures are predictable.</p></article>
+          <article class="flat-block" data-reveal><h3>Safe AI Adoption</h3><p>Acceleration only counts when controls and auditability stay intact.</p></article>
+        </div>
       </div>
     </section>
 
-    <section id="contact" class="section section-inverse cta" aria-labelledby="contact-title" data-section data-reveal>
-      <h2 id="contact-title">{meta?.ctaPrimary}</h2>
-      <p>{meta?.ctaConsulting}</p>
-      <div class="cta-actions" role="group" aria-label="Contact actions">
-        <a class="btn" href="mailto:hello@webfoundry.au">Email</a>
-        <a class="btn" href="https://www.linkedin.com/in/neil-sinha-ai-engineer/" target="_blank" rel="noreferrer">LinkedIn</a>
+    <section id="case-studies" class="section section-surface" aria-labelledby="case-studies-title" data-section>
+      <div class="container-wide">
+        <h2 id="case-studies-title" class="section-title-primary" data-reveal>Case Studies</h2>
+        <div class="case-list">
+          {caseStudies.map((entry) => (
+            <article class="case-card" data-reveal>
+              <p class="case-context">{entry.data.companyContext}</p>
+              <h3>{entry.data.title}</h3>
+              <div class="metric-row">
+                {entry.data.impact.slice(0, 3).map((metric) => {
+                  const countMeta = countMetaByLabel[metric.label];
+                  return (
+                    <div class="metric-block" aria-label={`${metric.label} changed from ${metric.before} to ${metric.after}`}>
+                      <p class="metric-value">
+                        {metric.before} → {countMeta ? (
+                          <>
+                            {metric.after.includes('-') ? '-' : ''}
+                            <span data-count-from={countMeta.from} data-count-to={countMeta.to}>{countMeta.to}</span>
+                            {metric.after.replace(/-?\d+/, '')}
+                          </>
+                        ) : metric.after}
+                      </p>
+                      <p class="metric-label">{metric.label}</p>
+                    </div>
+                  );
+                })}
+              </div>
+              {caseVisualBySlug[entry.data.slug] && (
+                <img class="case-visual" src={caseVisualBySlug[entry.data.slug]} alt={`Architecture summary for ${entry.data.title}`} loading="lazy" />
+              )}
+              <p><strong>Problem:</strong> {entry.data.problem}</p>
+              <p><strong>Intervention:</strong> {entry.data.intervention}</p>
+              <p><strong>Tradeoff:</strong> {entry.data.tradeoffs}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section id="ai-governance" class="section section-primary" aria-labelledby="governance-title" data-section>
+      <div class="container-wide">
+        <h2 id="governance-title" data-reveal>AI Governance in Practice</h2>
+        <div class="governance-grid" data-reveal-stagger>
+          {aiGovernance.map((entry, index) => (
+            <article class={`governance-card severity-${index === 1 ? 'medium' : 'high'}`} data-reveal>
+              <h3>{entry.data.title}</h3>
+              <p><strong>Failure mode:</strong> {entry.data.failureMode}</p>
+              <p><strong>Blast radius:</strong> {entry.data.blastRadius}</p>
+              <p><strong>Guardrail:</strong> {entry.data.guardrailAdded}</p>
+              <p class="risk-reduction"><strong>Risk reduction:</strong> {entry.data.riskReduction}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section id="experience" class="section section-surface" aria-labelledby="experience-title" data-section>
+      <div class="container-wide">
+        <h2 id="experience-title" class="section-title-primary" data-reveal>Experience</h2>
+        <div class="timeline" data-reveal-stagger>
+          {experience.map((entry, index) => (
+            <article class={`timeline-item ${index === 0 ? 'current' : ''}`} data-reveal>
+              <div class="timeline-meta">
+                <p>{entry.data.period}</p>
+                <p>{entry.data.company}</p>
+              </div>
+              <div class="timeline-body">
+                <h3>{entry.data.title}</h3>
+                <p>{entry.data.summary}</p>
+                <ul>
+                  {entry.data.highlights.map((h) => <li>{h}</li>)}
+                </ul>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section id="web-foundry" class="section section-primary" aria-labelledby="web-foundry-title" data-section>
+      <div class="container-narrow">
+        <h2 id="web-foundry-title" data-reveal>Web Foundry</h2>
+        <article class="web-foundry-card" data-reveal>
+          <p>Operator-led consulting across platform modernization, cost governance, and release reliability for delivery-focused teams.</p>
+          <div class="tag-row"><span>Cloud Cost Control</span><span>CI/CD Reliability</span><span>AI Governance Controls</span></div>
+        </article>
+      </div>
+    </section>
+
+    <section id="trust" class="section section-primary" aria-labelledby="trust-title" data-section>
+      <div class="container-narrow">
+        <h2 id="trust-title" data-reveal>Trust Layer</h2>
+        <p class="subtitle" data-reveal>Trusted across enterprise, scale-up, and research environments with measured delivery outcomes.</p>
+        <div class="logo-strip" aria-label="Organizations and institutions" data-reveal>
+          <span>ANZ</span>
+          <span>Humanforce</span>
+          <span>mPrest</span>
+          <span>Monash</span>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact" class="section section-deep cta" aria-labelledby="contact-title" data-section data-reveal>
+      <div class="container-narrow">
+        <h2 id="contact-title">{meta?.ctaPrimary}</h2>
+        <p>{meta?.ctaConsulting}</p>
+        <div class="cta-actions" role="group" aria-label="Contact actions">
+          <a class="btn" href="mailto:hello@webfoundry.au">Email</a>
+          <a class="btn" href="https://www.linkedin.com/in/neil-sinha-ai-engineer/" target="_blank" rel="noreferrer">LinkedIn</a>
+        </div>
       </div>
     </section>
   </main>
 </Layout>
 
-<script>
-  // @ts-nocheck
-  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  const sections = [...document.querySelectorAll('section[data-section]')];
-  const navLinks = [...document.querySelectorAll('[data-navlink]')];
-  const progress = document.querySelector('[data-scroll-progress]');
-  const revealEls = [...document.querySelectorAll('[data-reveal]')];
-  const staggerGroups = [...document.querySelectorAll('[data-reveal-stagger]')];
-  const counters = [...document.querySelectorAll('[data-count-up]')];
-  const heroSplit = document.querySelector('.hero-split');
-  const heroSides = [...document.querySelectorAll('[data-hero-side]')];
-
-  const setActive = (id) => {
-    navLinks.forEach((link) => {
-      const active = link.getAttribute('href') === `#${id}`;
-      if (active) link.setAttribute('aria-current', 'true');
-      else link.removeAttribute('aria-current');
-    });
-  };
-
-  const animateCounter = (el) => {
-    if (prefersReduced || el.dataset.animated === 'true') return;
-    const from = Number(el.dataset.countFrom ?? 0);
-    const to = Number(el.dataset.countTo ?? 0);
-    const duration = 1100;
-    const start = performance.now();
-    const step = (now) => {
-      const t = Math.min(1, (now - start) / duration);
-      const eased = 1 - Math.pow(1 - t, 4);
-      const value = Math.round(from + (to - from) * eased);
-      el.textContent = `${value}`;
-      if (t < 1) requestAnimationFrame(step);
-      else el.dataset.animated = 'true';
-    };
-    requestAnimationFrame(step);
-  };
-
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      if (!entry.isIntersecting) return;
-      entry.target.setAttribute('data-visible', 'true');
-      if (entry.target.matches('[data-count-up]')) animateCounter(entry.target);
-      observer.unobserve(entry.target);
-    });
-  }, { threshold: 0.15 });
-
-  revealEls.forEach((el) => observer.observe(el));
-  counters.forEach((el) => observer.observe(el));
-  heroSides.forEach((el) => {
-    const side = el.getAttribute('data-hero-side');
-    const activate = () => heroSplit?.setAttribute('data-hero-focus', side || '');
-    el.addEventListener('mouseenter', activate);
-    el.addEventListener('focus', activate);
-  });
-  heroSplit?.addEventListener('mouseleave', () => heroSplit.removeAttribute('data-hero-focus'));
-
-  staggerGroups.forEach((group) => {
-    [...group.children].forEach((child) => {
-      child.setAttribute('data-reveal', '');
-      observer.observe(child);
-    });
-  });
-
-  if (sections.length > 0) {
-    const navObserver = new IntersectionObserver((entries) => {
-      const visible = entries
-        .filter((e) => e.isIntersecting)
-        .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
-      if (visible?.target?.id) setActive(visible.target.id);
-    }, { threshold: [0.2, 0.5, 0.75] });
-
-    sections.forEach((section) => navObserver.observe(section));
-  }
-
-  const themeToggle = document.querySelector('[data-theme-toggle]');
-  const themeLabel = () => {
-    const current = document.documentElement.getAttribute('data-theme') || 'light';
-    if (themeToggle) themeToggle.textContent = current === 'dark' ? 'Dark' : 'Light';
-  };
-  themeLabel();
-  themeToggle?.addEventListener('click', () => {
-    const current = document.documentElement.getAttribute('data-theme') || 'light';
-    const next = current === 'dark' ? 'light' : 'dark';
-    document.documentElement.setAttribute('data-theme', next);
-    localStorage.setItem('portfolio-theme', next);
-    themeLabel();
-  });
-
-  const updateProgress = () => {
-    if (!progress) return;
-    const scrollTop = window.scrollY;
-    const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
-    const pct = scrollHeight > 0 ? Math.min(100, Math.max(0, (scrollTop / scrollHeight) * 100)) : 0;
-    progress.style.width = `${pct}%`;
-    document.documentElement.style.setProperty('--scroll-y', `${Math.min(8, scrollTop * 0.02)}px`);
-  };
-
-  updateProgress();
-  window.addEventListener('scroll', updateProgress, { passive: true });
-</script>
-
 <style>
-  .page { max-width: 1100px; margin: 0 auto; padding: var(--space-xl) 1.25rem var(--space-3xl); }
-  .section { margin: 0 0 var(--space-section); scroll-margin-top: 96px; position: relative; padding: var(--space-lg); border-radius: var(--radius-lg); }
-  .section:nth-of-type(even) { background: color-mix(in oklab, var(--bg-elevated) 72%, transparent); }
-  .section + .section::before {
+  .container-narrow { max-width: var(--content-max-width); margin: 0 auto; padding: 0 1.25rem; }
+  .container-wide { max-width: var(--content-wide-max-width); margin: 0 auto; padding: 0 1.25rem; }
+
+  .section { padding-top: var(--space-section); padding-bottom: var(--space-section); }
+  .section-primary { background: var(--bg-primary); }
+  .section-surface { background: var(--bg-surface); }
+  .section-deep { background: var(--bg-deep); }
+
+  .hero-split { background: var(--bg-primary); }
+  .hero-panels { display: grid; grid-template-columns: 1fr 1fr; min-height: 50vh; }
+  .hero-panel { padding: var(--space-3xl); }
+  .hero-panel h2 { margin: var(--space-sm) 0 var(--space-md); font-size: clamp(1.5rem, 3vw, 2rem); color: var(--text-primary); font-weight: 700; }
+  .hero-panel ul { margin: 0; padding-left: 1.15rem; color: var(--text-secondary); font-size: var(--text-small); }
+  .hero-label { color: var(--text-muted); font-size: var(--text-label); letter-spacing: var(--tracking-widest); text-transform: uppercase; }
+  .hero-label-accent { color: var(--text-accent); }
+  .hero-panel-platform { background: var(--bg-elevated); }
+  .hero-panel-data { background: var(--bg-deep); clip-path: polygon(8% 0, 100% 0, 100% 100%, 0% 100%); }
+  .hero-panel-data h2 { font-family: var(--font-mono); }
+
+  .hero-unified { background: var(--bg-primary); padding-top: var(--space-section); padding-bottom: var(--space-3xl); }
+  .eyebrow { color: var(--text-muted); font-size: var(--text-label); letter-spacing: var(--tracking-widest); text-transform: uppercase; }
+  h1 { font-size: var(--text-hero); line-height: var(--leading-tight); letter-spacing: var(--tracking-tight); margin: var(--space-sm) 0 var(--space-lg); max-width: 17ch; font-weight: 800; }
+  h2 { color: var(--text-primary); font-size: var(--text-section); margin: 0 0 var(--space-xl); font-weight: 700; }
+  .section-title-primary { font-weight: 800; }
+  .section-title-primary::after {
     content: '';
-    position: absolute;
-    left: 12%;
-    right: 12%;
-    top: calc(var(--space-section) * -0.5);
-    height: 1px;
-    background: linear-gradient(to right, transparent, var(--border-default), transparent);
+    display: block;
+    width: 48px;
+    height: 3px;
+    margin-top: var(--space-sm);
+    background: var(--accent);
+    border-radius: 2px;
   }
-  .eyebrow { font-size: var(--text-small); text-transform: uppercase; letter-spacing: .08em; color: var(--text-muted); }
-  h1 { font-size: var(--text-hero); line-height: var(--leading-tight); max-width: 16ch; margin: var(--space-xs) 0 var(--space-md); }
-  h2 { font-size: var(--text-section); margin-bottom: var(--space-lg); }
-  h3 { font-size: var(--text-card-title); margin: 0 0 var(--space-sm); }
-  .subtitle { color: var(--text-secondary); max-width: 70ch; line-height: var(--leading-normal); }
+  h3 { color: var(--text-primary); font-size: var(--text-card-title); margin: 0 0 var(--space-sm); font-weight: 700; }
+  .subtitle { color: var(--text-secondary); max-width: 600px; }
 
-  .hero-split { padding: 0; overflow: hidden; }
-  .hero-panels {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    min-height: 300px;
-    border-bottom: 1px solid var(--border-default);
-  }
-  .hero-panel {
-    padding: var(--space-xl);
-    transition: transform var(--duration-normal) var(--ease-out), background-color var(--duration-normal) var(--ease-out), opacity var(--duration-normal) var(--ease-out);
-  }
-  .hero-panel h2 { margin: .35rem 0 .65rem; font-size: clamp(1.35rem, 2.4vw, 1.85rem); letter-spacing: -0.02em; }
-  .hero-panel ul { margin: 0; padding-left: 1.1rem; color: var(--text-secondary); }
-  .hero-panel-label { margin: 0; font-size: var(--text-xs); text-transform: uppercase; letter-spacing: .08em; color: var(--text-muted); }
-  .hero-panel-platform {
-    background: color-mix(in oklab, var(--bg-inverse) 88%, black 12%);
-    color: var(--text-inverse);
-  }
-  .hero-panel-platform .hero-panel-label,
-  .hero-panel-platform ul { color: var(--text-inverse-muted); }
-  .hero-panel-data {
-    background: color-mix(in oklab, var(--bg-elevated) 78%, var(--bg-surface));
-    clip-path: polygon(8% 0, 100% 0, 100% 100%, 0 100%);
-    padding-left: calc(var(--space-xl) + 1rem);
-  }
-  .hero-unified { padding: var(--space-xl); }
-  .hero-split[data-hero-focus='platform'] .hero-panel-data { opacity: .72; transform: translateX(4px); }
-  .hero-split[data-hero-focus='data'] .hero-panel-platform { opacity: .72; transform: translateX(-4px); }
+  .proof-pills { display: flex; flex-wrap: wrap; gap: var(--space-sm); margin-top: var(--space-lg); }
+  .proof-pills span { border: 1px solid var(--border-medium); border-radius: var(--radius-sm); padding: var(--space-xs) var(--space-md); font-size: var(--text-small); color: var(--text-secondary); font-variant-numeric: tabular-nums; }
 
-  [data-reveal] {
-    opacity: 0;
-    transform: translateY(16px);
-    transition: opacity var(--duration-slow) var(--ease-out), transform var(--duration-slow) var(--ease-out);
-  }
-  [data-reveal][data-visible='true'] {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  .problem-grid { display: grid; gap: var(--space-md); grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+  .problem-grid article { background: var(--bg-elevated); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); padding: var(--space-lg); }
+  .problem-grid p { color: var(--text-secondary); }
+  .stat { margin: 0 0 var(--space-sm); color: var(--text-accent); font-size: var(--text-stat); font-weight: 700; }
 
-  [data-reveal-stagger] > *:nth-child(1) { transition-delay: 0ms; }
-  [data-reveal-stagger] > *:nth-child(2) { transition-delay: 80ms; }
-  [data-reveal-stagger] > *:nth-child(3) { transition-delay: 160ms; }
-  [data-reveal-stagger] > *:nth-child(4) { transition-delay: 240ms; }
-  [data-reveal-stagger] > *:nth-child(5) { transition-delay: 320ms; }
-
-  .proof-pills, .tag-row { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-top: var(--space-md); }
-  .proof-pills span, .tag-row span { font-size: var(--text-small); padding: .4rem .65rem; border-radius: var(--radius-md); background: var(--bg-elevated); border: 1px solid var(--border-default); }
-
-  .section-inverse { background: var(--bg-inverse); color: var(--text-inverse); border-radius: var(--radius-lg); padding: var(--space-xl); }
-  .section-inverse h2, .section-inverse p { color: var(--text-inverse); }
-
-  .problem-grid { display: grid; gap: var(--space-md); grid-template-columns: repeat(auto-fit,minmax(220px,1fr)); }
-  .problem-grid article { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: var(--space-md); }
-  .stat { font-size: 2rem; font-weight: 700; margin: 0 0 .25rem; color: var(--accent); font-variant-numeric: tabular-nums; }
-
-  .philosophy-grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(240px,1fr)); gap: var(--space-lg); }
-  .flat-block { padding: 0; }
-  .flat-block p { color: var(--text-secondary); line-height: var(--leading-normal); }
+  .philosophy-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: var(--space-lg); }
+  .flat-block p { color: var(--text-secondary); }
 
   .case-list { display: grid; gap: var(--space-lg); }
-  .case-card { background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-lg); padding: var(--space-lg); box-shadow: var(--shadow-md); transition: transform var(--duration-normal) var(--ease-out), box-shadow var(--duration-normal) var(--ease-out); }
-  .case-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-hover); }
-  .case-context { margin: 0 0 .35rem; font-size: var(--text-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
-  .metric-row { display: grid; gap: var(--space-sm); grid-template-columns: repeat(auto-fit,minmax(190px,1fr)); margin: var(--space-md) 0; }
-  .metric-block { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: .6rem .75rem; }
-  .metric-value { margin: 0; font-size: 1.35rem; line-height: 1.2; color: var(--accent); font-weight: 700; font-variant-numeric: tabular-nums; }
-  .metric-label { margin: .2rem 0 0; font-size: var(--text-xs); color: var(--text-muted); }
-  .case-visual { width: 100%; border: 1px solid var(--border-default); border-radius: var(--radius-md); background: var(--bg-primary); margin: .25rem 0 var(--space-md); }
-
-  .compact-grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); gap: var(--space-md); }
-  .dense-card { background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: var(--space-md); }
-  .dense-card p, .dense-card li { color: var(--text-secondary); line-height: var(--leading-normal); }
-  .dense-card ul { margin: .5rem 0 0; padding-left: 1rem; }
-  .dense-card li.secondary { opacity: 0.68; font-size: 0.96em; }
-  .dense-kicker { margin: .2rem 0 .4rem; }
-
-  .elevated-block { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: var(--space-lg); }
-
-  .logo-strip { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-top: var(--space-md); }
-  .logo-strip span {
-    padding: .4rem .65rem;
-    border: 1px solid var(--border-default);
-    border-radius: 999px;
-    font-size: var(--text-small);
-    color: var(--text-secondary);
-    background: var(--bg-surface);
-    letter-spacing: 0.02em;
+  .case-card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-card);
+    padding: var(--space-xl);
+    transition: all var(--duration-normal) var(--ease-out);
   }
+  .case-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-card-hover); border-color: var(--border-medium); }
+  .case-context { color: var(--text-accent); font-size: var(--text-xs); letter-spacing: var(--tracking-wide); text-transform: uppercase; margin: 0 0 var(--space-xs); }
+  .metric-row { display: grid; gap: var(--space-sm); grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); margin: var(--space-lg) 0; }
+  .metric-block { background: var(--bg-primary); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); padding: var(--space-sm) var(--space-md); }
+  .metric-value { margin: 0; color: var(--text-accent); font-weight: 700; font-size: 1.35rem; }
+  .metric-label { margin: var(--space-xs) 0 0; color: var(--text-muted); font-size: var(--text-xs); }
+  .case-card p { color: var(--text-secondary); }
+  .case-visual { width: 100%; background: var(--bg-primary); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); padding: var(--space-md); margin-bottom: var(--space-md); }
 
-  .cta { margin-bottom: 0; }
-  .cta-actions { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-top: var(--space-md); }
-  .btn { display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-md); padding: .6rem .95rem; font-weight: 600; text-decoration: none; background: var(--bg-surface); color: var(--text-primary); border: 1px solid transparent; }
-  .btn:hover { background: var(--accent-subtle); border-color: color-mix(in oklab, var(--accent) 35%, transparent); }
+  .governance-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: var(--space-md); }
+  .governance-card { background: var(--bg-elevated); border-radius: var(--radius-md); border: 1px solid var(--border-subtle); border-left: 3px solid var(--severity-high); padding: var(--space-lg); }
+  .governance-card.severity-medium { border-left-color: var(--severity-medium); }
+  .governance-card p { color: var(--text-secondary); }
+  .risk-reduction { color: var(--severity-resolved) !important; }
 
-
-  @media (max-width: 900px) {
-    .hero-panels { grid-template-columns: 1fr; min-height: unset; }
-    .hero-panel-data { clip-path: none; padding-left: var(--space-xl); }
+  .timeline { display: grid; gap: var(--space-lg); position: relative; }
+  .timeline::before { content: ''; position: absolute; left: 201px; top: 0; bottom: 0; width: 2px; background: var(--border-subtle); }
+  .timeline-item { display: grid; grid-template-columns: 200px 1fr; gap: var(--space-xl); position: relative; }
+  .timeline-item::before {
+    content: '';
+    position: absolute;
+    left: 194px;
+    top: 0.35rem;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--bg-elevated);
+    border: 2px solid var(--border-medium);
   }
+  .timeline-item.current::before { background: var(--accent-glow); border-color: var(--accent); box-shadow: 0 0 0 6px var(--accent-glow); }
+  .timeline-meta { color: var(--text-muted); font-size: var(--text-small); }
+  .timeline-meta p { margin: 0 0 var(--space-xs); }
+  .timeline-body p, .timeline-body li { color: var(--text-secondary); font-size: var(--text-small); }
+  .timeline-body ul { margin: var(--space-sm) 0 0; padding-left: 1rem; }
 
-  @media (prefers-reduced-motion: reduce) {
-    [data-reveal] { opacity: 1; transform: none; transition: none; }
-    .case-card { transition: none; }
-    .case-card:hover { transform: none; box-shadow: var(--shadow-md); }
+  .web-foundry-card { background: var(--bg-elevated); border: 1px solid var(--border-accent); border-radius: var(--radius-lg); padding: var(--space-xl); }
+  .web-foundry-card p { color: var(--text-secondary); }
+  .tag-row { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-top: var(--space-lg); }
+  .tag-row span { border: 1px solid var(--border-medium); color: var(--text-secondary); border-radius: var(--radius-sm); padding: var(--space-xs) var(--space-md); font-size: var(--text-small); }
+
+  .logo-strip { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-top: var(--space-lg); }
+  .logo-strip span { border: 1px solid var(--border-medium); border-radius: var(--radius-sm); padding: var(--space-xs) var(--space-md); font-size: var(--text-small); color: var(--text-primary); font-weight: 500; letter-spacing: var(--tracking-wide); }
+
+  .cta p { color: var(--text-secondary); }
+  .cta-actions { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-top: var(--space-lg); }
+  .btn { display: inline-flex; align-items: center; justify-content: center; text-decoration: none; border-radius: var(--radius-md); padding: 0.6rem 0.95rem; color: var(--text-primary); background: var(--bg-elevated); border: 1px solid var(--border-subtle); }
+  .btn:hover { border-color: var(--border-accent); background: var(--accent-glow); }
+
+  @media (max-width: 768px) {
+    .hero-panels { grid-template-columns: 1fr; min-height: auto; }
+    .hero-panel { padding: var(--space-xl); }
+    .hero-panel-data { clip-path: none; }
+
+    .timeline::before { display: none; }
+    .timeline-item { grid-template-columns: 1fr; gap: var(--space-sm); }
+    .timeline-item::before { display: none; }
   }
 </style>


### PR DESCRIPTION
## Summary
- promote refined split-hero visual system to main
- apply dark-mode-only design token foundation and remove theme toggle
- standardize section rhythm, card hierarchy, timeline restoration, flow-diagram color system
- keep accessibility/motion guardrails (skip link, focus-visible, reduced-motion-safe reveal/count behavior)

## Why
Issue #46 promotes the approved refined feature-branch experience as the single canonical portfolio version.

Closes #46

## Tests
- `cd web && npm run astro -- check`
- `cd web && npm run build`
- `cd web && du -sh dist/`
- Result: pass; dist size ~60K

## Risk & Rollback
- Risk: visual system changes are broad and may require minor contrast/spacing tuning.
- Rollback: revert this PR commit from main.

## Security & Data
- Frontend presentation-only changes; no auth/data changes.
