### PR TITLE
feat(marketing): update CTA links and SEO crawler metadata

### DIFF
--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://neil.webfoundryprivatelimited.com/sitemap.xml

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://neil.webfoundryprivatelimited.com</loc>
+    <lastmod>2026-03-23</lastmod>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -6,7 +6,17 @@
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="generator" content={Astro.generator} />
-		<title>Neil Sinha · IT Portfolio</title>
+		<title>Neil Sinha — Platform + AI Engineering</title>
+		<meta name="description" content="Senior Platform / AI-ML Platform Engineer focused on cost control, delivery reliability, and safe AI operations. Based in Melbourne, Australia." />
+		<meta name="author" content="Neil Sinha" />
+		<meta property="og:title" content="Neil Sinha — Platform + AI Engineering" />
+		<meta property="og:description" content="I design systems that are both reliable and adaptive. Senior Platform Engineer focused on cost control, delivery reliability, and safe AI operations." />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://neil.webfoundryprivatelimited.com" />
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content="Neil Sinha — Platform + AI Engineering" />
+		<meta name="twitter:description" content="I design systems that are both reliable and adaptive." />
+		<link rel="canonical" href="https://neil.webfoundryprivatelimited.com" />
 	</head>
 	<body>
 		<slot />

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -245,9 +245,11 @@ const meta = metaEntry?.data;
       <div class="container-wide">
         <h2 id="contact-title">{meta?.ctaPrimary}</h2>
         <p>{meta?.ctaConsulting}</p>
+        <p class="contact-lines">Business inquiries: neil@webfoundryprivatelimited.com<br />Career opportunities: aaditya.n.sinha@gmail.com</p>
         <div class="cta-actions" role="group" aria-label="Contact actions">
-          <a class="btn" href="mailto:hello@webfoundry.au">Email</a>
-          <a class="btn" href="https://www.linkedin.com/in/neil-sinha-ai-engineer/" target="_blank" rel="noreferrer">LinkedIn</a>
+          <a class="btn" href="mailto:neil@webfoundryprivatelimited.com?subject=Web%20Foundry%20Inquiry">Get in touch</a>
+          <a class="btn" href="https://www.linkedin.com/in/aaditya-neil-sinha/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+          <a class="btn" href="/neil-sinha-resume.pdf" target="_blank" rel="noopener noreferrer">Download resume</a>
         </div>
       </div>
     </section>
@@ -364,6 +366,7 @@ const meta = metaEntry?.data;
   .testimonial-author span { font-size: 0.75rem; color: var(--text-muted); font-style: normal; }
 
   .cta p { color: var(--text-secondary); }
+  .contact-lines { font-size: 0.875rem; color: var(--text-muted); margin-top: -0.5rem; margin-bottom: 0.5rem; line-height: 1.55; }
   .cta-actions { display: flex; gap: var(--space-sm); flex-wrap: wrap; margin-top: var(--space-lg); }
   .btn { display: inline-flex; align-items: center; justify-content: center; text-decoration: none; border-radius: var(--radius-md); padding: 0.6rem 0.95rem; color: var(--text-primary); background: var(--bg-elevated); border: 1px solid var(--border-subtle); }
   .btn:hover { border-color: var(--border-accent); background: var(--accent-glow); }


### PR DESCRIPTION
## Summary
Closes #55

Applies CTA/contact-link and SEO/crawler polish:
- updates CTA mailto + LinkedIn target URL
- adds resume placeholder link button
- adds business/career contact detail lines below CTA subtitle
- adds page-level SEO + social meta tags + canonical
- adds `robots.txt` and `sitemap.xml`

## Why
Improves conversion/contact routing accuracy and baseline search/social discoverability while keeping visual structure intact.

## Tests
- `cd web && npm run build` ✅
- local canonical rollout verified on `http://127.0.0.1:18081` ✅
- runtime checks:
  - `/robots.txt` returns expected content ✅
  - `/sitemap.xml` returns expected URL entry ✅
  - updated CTA mailto appears in served HTML ✅

## Risk & Rollback
- Risk: low (static frontend changes only)
- Rollback: revert merge commit or redeploy prior known-good image tag

## Security & Data
- No secrets/auth/runtime privilege changes
- No backend/API/data-path changes
- frontend metadata/content/static files only
